### PR TITLE
Add Google OAuth admin login

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Standalone PHP application for uploading store photos/videos to Google Drive.
 3. Upload the project files to your PHP host.
 4. Access `public/index.php` for store uploads and `admin/login.php` for the admin portal.
 
+### Google Login
+
+Fill in the `google_oauth` settings in `config.php` to enable "Login with Google" on the admin login page. The email returned by Google must match a username in the `users` table.
+
 ## Deployment
 
 A simple `deploy.sh` script is provided to rsync the files to a remote host. Edit the script with your server details.

--- a/admin/google_callback.php
+++ b/admin/google_callback.php
@@ -1,0 +1,54 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/auth.php';
+
+$config = require __DIR__.'/../config.php';
+
+if (!isset($_GET['code'])) {
+    exit('Missing code');
+}
+$code = $_GET['code'];
+
+$tokenParams = [
+    'code' => $code,
+    'client_id' => $config['google_oauth']['client_id'],
+    'client_secret' => $config['google_oauth']['client_secret'],
+    'redirect_uri' => $config['google_oauth']['redirect_uri'],
+    'grant_type' => 'authorization_code',
+];
+$ch = curl_init('https://oauth2.googleapis.com/token');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_POSTFIELDS => http_build_query($tokenParams),
+]);
+$resp = curl_exec($ch);
+if (curl_errno($ch)) {
+    exit('Curl error');
+}
+$data = json_decode($resp, true);
+$accessToken = $data['access_token'] ?? null;
+if (!$accessToken) {
+    exit('Token error');
+}
+
+$ch = curl_init('https://www.googleapis.com/oauth2/v3/userinfo');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER => ['Authorization: Bearer ' . $accessToken],
+]);
+$userResp = curl_exec($ch);
+if (curl_errno($ch)) {
+    exit('Curl error');
+}
+$userInfo = json_decode($userResp, true);
+$email = $userInfo['email'] ?? null;
+
+if ($email && login_with_google_email($email)) {
+    header('Location: index.php');
+    exit;
+} else {
+    exit('No admin user for this Google account');
+}
+?>
+

--- a/admin/google_login.php
+++ b/admin/google_login.php
@@ -1,0 +1,15 @@
+<?php
+$config = require __DIR__.'/../config.php';
+$params = [
+    'client_id' => $config['google_oauth']['client_id'],
+    'redirect_uri' => $config['google_oauth']['redirect_uri'],
+    'response_type' => 'code',
+    'scope' => 'openid email',
+    'include_granted_scopes' => 'true',
+    'prompt' => 'select_account',
+];
+$url = 'https://accounts.google.com/o/oauth2/v2/auth?' . http_build_query($params);
+header('Location: ' . $url);
+exit;
+?>
+

--- a/admin/login.php
+++ b/admin/login.php
@@ -28,5 +28,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <div class="input-field"><input type="password" name="password" id="password" required><label for="password">Password</label></div>
     <button class="btn" type="submit">Login</button>
 </form>
+<p><a class="btn red" href="google_login.php">Login with Google</a></p>
 </body>
 </html>

--- a/config.example.php
+++ b/config.example.php
@@ -11,4 +11,10 @@ return [
     'service_account_json' => __DIR__.'/service-account.json',
     'drive_base_folder' => '',
     'notification_email' => 'admin@example.com',
+    'google_oauth' => [
+        'client_id' => '',
+        'client_secret' => '',
+        // URL to google_callback.php in your installation
+        'redirect_uri' => 'http://yourdomain.com/admin/google_callback.php',
+    ],
 ];

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -28,3 +28,16 @@ function logout() {
     $_SESSION = [];
     session_destroy();
 }
+
+function login_with_google_email($email): bool {
+    $pdo = get_pdo();
+    $stmt = $pdo->prepare('SELECT id FROM users WHERE username=?');
+    $stmt->execute([$email]);
+    if ($row = $stmt->fetch()) {
+        session_start();
+        session_regenerate_id(true);
+        $_SESSION['user_id'] = $row['id'];
+        return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- support Google OAuth configuration
- add Login with Google button in admin
- implement OAuth flow endpoints
- document Google login setup

## Testing
- `php -l admin/google_login.php`
- `php -l admin/google_callback.php`
- `php -l admin/login.php`
- `php -l lib/auth.php`
- `php tests/dbtest.php` *(fails: Failed opening required '../config.php')*

------
https://chatgpt.com/codex/tasks/task_e_6864b23675ac83268e6e922afc2bb72a