### PR TITLE
Add shared headers/footers for consistent styling

### DIFF
--- a/admin/footer.php
+++ b/admin/footer.php
@@ -1,0 +1,5 @@
+</div>
+<script src="../assets/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>
+

--- a/admin/header.php
+++ b/admin/header.php
@@ -1,0 +1,29 @@
+<?php
+if (!isset($active)) { $active = ''; }
+?>
+<!doctype html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../assets/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.php">Admin</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminNav" aria-controls="adminNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="adminNav">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link<?php if($active==='dashboard') echo ' active'; ?>" href="index.php">Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link<?php if($active==='stores') echo ' active'; ?>" href="stores.php">Stores</a></li>
+        <li class="nav-item"><a class="nav-link<?php if($active==='uploads') echo ' active'; ?>" href="uploads.php">Uploads</a></li>
+        <li class="nav-item"><a class="nav-link<?php if($active==='settings') echo ' active'; ?>" href="settings.php">Settings</a></li>
+        <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">
+

--- a/admin/index.php
+++ b/admin/index.php
@@ -2,40 +2,15 @@
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
 require_login();
+$active = 'dashboard';
+include __DIR__.'/header.php';
 ?>
-<!doctype html>
-<html>
-<head>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href="../assets/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="index.php">Admin</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminNav" aria-controls="adminNav" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="adminNav">
-      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="index.php">Dashboard</a></li>
-        <li class="nav-item"><a class="nav-link" href="stores.php">Stores</a></li>
-        <li class="nav-item"><a class="nav-link" href="uploads.php">Uploads</a></li>
-        <li class="nav-item"><a class="nav-link" href="settings.php">Settings</a></li>
-        <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
-<div class="container">
 <h4>Admin Dashboard</h4>
 <ul class="list-group">
-<li class="list-group-item"><a href="stores.php">Store Management</a></li>
-<li class="list-group-item"><a href="uploads.php">Content Review</a></li>
-<li class="list-group-item"><a href="settings.php">Settings</a></li>
-<li class="list-group-item"><a href="logout.php">Logout</a></li>
+  <li class="list-group-item"><a href="stores.php">Store Management</a></li>
+  <li class="list-group-item"><a href="uploads.php">Content Review</a></li>
+  <li class="list-group-item"><a href="settings.php">Settings</a></li>
+  <li class="list-group-item"><a href="logout.php">Logout</a></li>
 </ul>
-</div>
-<script src="../assets/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+<?php include __DIR__.'/footer.php'; ?>
+

--- a/admin/login.php
+++ b/admin/login.php
@@ -2,8 +2,8 @@
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
 
-session_start();
 $errors = [];
+session_start();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (login($_POST['username'], $_POST['password'])) {
@@ -14,23 +14,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 ?>
-<!doctype html>
-<html>
-<head>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href="../assets/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Admin</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarLogin" aria-controls="navbarLogin" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarLogin"></div>
-  </div>
-</nav>
-<div class="container mt-4">
+<?php include __DIR__.'/login_header.php'; ?>
 <h4>Admin Login</h4>
 <?php foreach ($errors as $e) echo "<div class=\"alert alert-danger\">$e</div>"; ?>
 <form method="post">
@@ -46,6 +30,5 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </form>
 <p class="mt-3"><a class="btn btn-danger" href="google_login.php">Login with Google</a></p>
 </div>
-<script src="../assets/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+<?php include __DIR__.'/footer.php'; ?>
+

--- a/admin/login_header.php
+++ b/admin/login_header.php
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../assets/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">Admin</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarLogin" aria-controls="navbarLogin" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarLogin"></div>
+  </div>
+</nav>
+<div class="container mt-4">
+

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -27,32 +27,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 $drive_folder = get_setting('drive_base_folder');
 $notify_email = get_setting('notification_email');
+$active = 'settings';
+include __DIR__.'/header.php';
 ?>
-<!doctype html>
-<html>
-<head>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href="../assets/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="index.php">Admin</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminNav" aria-controls="adminNav" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="adminNav">
-      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="index.php">Dashboard</a></li>
-        <li class="nav-item"><a class="nav-link" href="stores.php">Stores</a></li>
-        <li class="nav-item"><a class="nav-link" href="uploads.php">Uploads</a></li>
-        <li class="nav-item"><a class="nav-link active" href="settings.php">Settings</a></li>
-        <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
-<div class="container">
 <h4>Settings</h4>
 <form method="post" enctype="multipart/form-data">
 <div class="mb-3">
@@ -69,7 +46,5 @@ $notify_email = get_setting('notification_email');
 </div>
 <button class="btn btn-primary" type="submit">Save</button>
 </form>
-</div>
-<script src="../assets/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+<?php include __DIR__.'/footer.php'; ?>
+

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -15,32 +15,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 $stores = $pdo->query('SELECT * FROM stores')->fetchAll(PDO::FETCH_ASSOC);
-?>
-<!doctype html>
-<html>
-<head>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href="../assets/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="index.php">Admin</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminNav" aria-controls="adminNav" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="adminNav">
-      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="index.php">Dashboard</a></li>
-        <li class="nav-item"><a class="nav-link active" href="stores.php">Stores</a></li>
-        <li class="nav-item"><a class="nav-link" href="uploads.php">Uploads</a></li>
-        <li class="nav-item"><a class="nav-link" href="settings.php">Settings</a></li>
-        <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
-<div class="container">
+$active = 'stores';
+include __DIR__.'/header.php';
 <h4>Store Management</h4>
 <table class="table table-striped">
 <tr><th>Name</th><th>PIN</th><th>Email</th><th>Folder</th><th></th></tr>
@@ -67,7 +43,5 @@ $stores = $pdo->query('SELECT * FROM stores')->fetchAll(PDO::FETCH_ASSOC);
 <div class="mb-3"><label for="folder" class="form-label">Drive Folder ID</label><input type="text" name="folder" id="folder" class="form-control"></div>
 <button class="btn btn-primary" name="add" type="submit">Add</button>
 </form>
-</div>
-<script src="../assets/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+<?php include __DIR__.'/footer.php'; ?>
+

--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -22,32 +22,8 @@ $sql .= ' ORDER BY u.created_at DESC LIMIT 50';
 $stmt = $pdo->prepare($sql);
 $stmt->execute($params);
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
-?>
-<!doctype html>
-<html>
-<head>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href="../assets/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="index.php">Admin</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminNav" aria-controls="adminNav" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="adminNav">
-      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="index.php">Dashboard</a></li>
-        <li class="nav-item"><a class="nav-link" href="stores.php">Stores</a></li>
-        <li class="nav-item"><a class="nav-link active" href="uploads.php">Uploads</a></li>
-        <li class="nav-item"><a class="nav-link" href="settings.php">Settings</a></li>
-        <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
-<div class="container">
+$active = 'uploads';
+include __DIR__.'/header.php';
 <h4>Recent Uploads</h4>
 <form method="get" class="row g-3 align-items-end">
 <div class="col-md-4">
@@ -78,6 +54,5 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 <?php endforeach; ?>
 </div>
 </div>
-<script src="../assets/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+<?php include __DIR__.'/footer.php'; ?>
+

--- a/public/footer.php
+++ b/public/footer.php
@@ -1,0 +1,5 @@
+</div>
+<script src="../assets/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>
+

--- a/public/header.php
+++ b/public/header.php
@@ -1,0 +1,27 @@
+<?php
+if (!isset($_SESSION)) { session_start(); }
+?>
+<!doctype html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link href="../assets/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">Store Upload</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarPublic" aria-controls="navbarPublic" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarPublic">
+      <ul class="navbar-nav ms-auto">
+        <?php if(isset($_SESSION['store_id'])): ?>
+        <li class="nav-item"><a class="nav-link" href="?logout=1">Change Store</a></li>
+        <?php endif; ?>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container mt-4">
+

--- a/public/index.php
+++ b/public/index.php
@@ -27,21 +27,21 @@ if (!isset($_SESSION['store_id'])) {
     }
     if (!isset($_SESSION['store_id'])) {
         // show PIN form
-        echo '<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1">';
-        echo '<link href="../assets/css/bootstrap.min.css" rel="stylesheet">';
-        echo '</head><body>';
-        echo '<nav class="navbar navbar-expand-lg navbar-dark bg-primary">';
-        echo '<div class="container-fluid">';
-        echo '<a class="navbar-brand" href="#">Store Upload</a>';
-        echo '<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarPublic" aria-controls="navbarPublic" aria-expanded="false" aria-label="Toggle navigation">';
-        echo '<span class="navbar-toggler-icon"></span></button>';
-        echo '<div class="collapse navbar-collapse" id="navbarPublic"></div></div></nav>';
-        echo '<div class="container mt-4"><h3>Enter Store PIN</h3>';
-        foreach ($errors as $e) echo "<div class=\"alert alert-danger\">$e</div>";
-        echo '<form method="post">';
-        echo '<div class="mb-3"><label for="pin" class="form-label">Store PIN</label><input type="text" name="pin" id="pin" class="form-control" required></div>';
-        echo '<button class="btn btn-primary" type="submit">Continue</button></form></div>';
-        echo '<script src="../assets/js/bootstrap.bundle.min.js"></script></body></html>';
+        include __DIR__.'/header.php';
+        ?>
+        <h3>Enter Store PIN</h3>
+        <?php foreach ($errors as $e): ?>
+        <div class="alert alert-danger"><?php echo $e; ?></div>
+        <?php endforeach; ?>
+        <form method="post">
+            <div class="mb-3">
+                <label for="pin" class="form-label">Store PIN</label>
+                <input type="text" name="pin" id="pin" class="form-control" required>
+            </div>
+            <button class="btn btn-primary" type="submit">Continue</button>
+        </form>
+        <?php
+        include __DIR__.'/footer.php';
         exit;
     }
 }
@@ -77,27 +77,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['files'])) {
 
 // show upload form
 ?>
-<!doctype html>
-<html>
-<head>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href="../assets/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-  <div class="container-fluid">
-    <a class="navbar-brand" href="#">Store Upload</a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarPublic2" aria-controls="navbarPublic2" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarPublic2">
-      <ul class="navbar-nav ms-auto">
-        <li class="nav-item"><a class="nav-link" href="?logout=1">Change Store</a></li>
-      </ul>
-    </div>
-  </div>
-</nav>
-<div class="container mt-4">
+include __DIR__.'/header.php';
+?>
 <h4>Upload Files for Store <?php echo htmlspecialchars($store_pin); ?></h4>
 <?php foreach ($errors as $e) echo "<div class=\"alert alert-danger\">$e</div>"; ?>
 <form method="post" enctype="multipart/form-data" id="uploadForm">
@@ -108,9 +89,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['files'])) {
     <div id="descriptions"></div>
     <button class="btn btn-primary" type="submit">Upload</button>
 </form>
-</div>
-
-<script src="../assets/js/bootstrap.bundle.min.js"></script>
 <script>
 const fileInput = document.querySelector('input[type=file]');
 fileInput.addEventListener('change', () => {
@@ -124,5 +102,5 @@ fileInput.addEventListener('change', () => {
   });
 });
 </script>
-</body>
-</html>
+<?php include __DIR__.'/footer.php'; ?>
+


### PR DESCRIPTION
## Summary
- add reusable header and footer partials for admin and public areas
- update all admin pages to include common layout
- update public index to use the new header/footer

## Testing
- `php tests/dbtest.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864bec0d4dc8326ae6b113ef05e2ecd