### PR TITLE
Fix admin uploads parse error

### DIFF
--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -24,6 +24,7 @@ $stmt->execute($params);
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 $active = 'uploads';
 include __DIR__.'/header.php';
+?>
 <h4>Recent Uploads</h4>
 <form method="get" class="row g-3 align-items-end">
 <div class="col-md-4">


### PR DESCRIPTION
## Summary
- close the initial PHP block in admin/uploads page

## Testing
- `php tests/dbtest.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686549138bb88326be64bb00bf850334