### PR TITLE
Fix parse error in stores.php

### DIFF
--- a/admin/stores.php
+++ b/admin/stores.php
@@ -17,6 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 $stores = $pdo->query('SELECT * FROM stores')->fetchAll(PDO::FETCH_ASSOC);
 $active = 'stores';
 include __DIR__.'/header.php';
+?>
 <h4>Store Management</h4>
 <table class="table table-striped">
 <tr><th>Name</th><th>PIN</th><th>Email</th><th>Folder</th><th></th></tr>


### PR DESCRIPTION
## Summary
- close PHP tag before HTML output in `admin/stores.php`

## Testing
- `php` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_686558b064688326a6fd33d440f04d38