### PR TITLE
Fix PHP include tags on public page

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -76,7 +76,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['files'])) {
 }
 
 // show upload form
-?>
 include __DIR__.'/header.php';
 ?>
 <h4>Upload Files for Store <?php echo htmlspecialchars($store_pin); ?></h4>


### PR DESCRIPTION
## Summary
- fix incorrect PHP closing tag in `public/index.php`

## Testing
- `php -l public/index.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68655e907d24832699ceefa8f128fd0d