### PR TITLE
Fix header include in admin login

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -13,8 +13,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $errors[] = 'Login failed';
     }
 }
+include __DIR__.'/login_header.php';
 ?>
-<?php include __DIR__.'/login_header.php'; ?>
 <h4>Admin Login</h4>
 <?php foreach ($errors as $e) echo "<div class=\"alert alert-danger\">$e</div>"; ?>
 <form method="post">


### PR DESCRIPTION
## Summary
- fix include block in `admin/login.php`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686562e128fc832687c92c44b069714d