### PR TITLE
Add config loader for missing config.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.php
+!lib/config.php
 service-account.json
 /tmp/

--- a/admin/google_callback.php
+++ b/admin/google_callback.php
@@ -1,8 +1,9 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
+require_once __DIR__.'/../lib/config.php';
 
-$config = require __DIR__.'/../config.php';
+$config = get_config();
 
 if (!isset($_GET['code'])) {
     exit('Missing code');

--- a/admin/google_login.php
+++ b/admin/google_login.php
@@ -1,5 +1,6 @@
 <?php
-$config = require __DIR__.'/../config.php';
+require_once __DIR__.'/../lib/config.php';
+$config = get_config();
 $params = [
     'client_id' => $config['google_oauth']['client_id'],
     'redirect_uri' => $config['google_oauth']['redirect_uri'],

--- a/lib/config.php
+++ b/lib/config.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Configuration loader. Attempts to load config.php and falls back to
+ * config.example.php if the real configuration file is missing. This
+ * avoids fatal errors during initial setup.
+ */
+function get_config(): array {
+    static $cfg;
+    if ($cfg !== null) {
+        return $cfg;
+    }
+    $primary = __DIR__ . '/../config.php';
+    if (file_exists($primary)) {
+        $cfg = require $primary;
+    } else {
+        $example = __DIR__ . '/../config.example.php';
+        if (file_exists($example)) {
+            $cfg = require $example;
+        } else {
+            throw new Exception('No configuration file found');
+        }
+    }
+    return $cfg;
+}

--- a/lib/db.php
+++ b/lib/db.php
@@ -1,10 +1,16 @@
 <?php
 /** Database connection helper */
+require_once __DIR__.'/config.php';
+
 function get_pdo(): PDO {
     static $pdo;
     if (!$pdo) {
-        $config = require __DIR__.'/../config.php';
-        $pdo = new PDO("mysql:host={$config['db']['host']};dbname={$config['db']['dbname']};charset=utf8mb4", $config['db']['user'], $config['db']['pass']);
+        $config = get_config();
+        $pdo = new PDO(
+            "mysql:host={$config['db']['host']};dbname={$config['db']['dbname']};charset=utf8mb4",
+            $config['db']['user'],
+            $config['db']['pass']
+        );
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     }
     return $pdo;

--- a/lib/drive.php
+++ b/lib/drive.php
@@ -1,8 +1,10 @@
 <?php
 /** Google Drive upload helper using service account and cURL */
 
+require_once __DIR__.'/config.php';
+
 function drive_get_access_token() {
-    $config = require __DIR__.'/../config.php';
+    $config = get_config();
     $creds = json_decode(file_get_contents($config['service_account_json']), true);
     $header = base64_encode(json_encode([
         'alg' => 'RS256',

--- a/public/index.php
+++ b/public/index.php
@@ -3,7 +3,7 @@
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/drive.php';
 
-$config = require __DIR__.'/../config.php';
+$config = get_config();
 
 session_start();
 $errors = [];

--- a/setup.php
+++ b/setup.php
@@ -1,8 +1,9 @@
 <?php
-/** 
+/**
  * Setup script to initialize database tables and create default admin user.
  */
-$config = require __DIR__.'/config.php';
+require_once __DIR__.'/lib/config.php';
+$config = get_config();
 
 try {
     $pdo = new PDO("mysql:host={$config['db']['host']};dbname={$config['db']['dbname']};charset=utf8mb4", $config['db']['user'], $config['db']['pass']);


### PR DESCRIPTION
## Summary
- load config.php via new helper that falls back to config.example.php
- use the loader in DB helper, Drive helper, setup, index, and Google auth pages
- whitelist the new helper file in `.gitignore`

## Testing
- `php tests/dbtest.php` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68656c045a6883268051c7abe2adb1a8