### PR TITLE
Add Hootsuite calendar skeleton

### DIFF
--- a/admin/stores.php
+++ b/admin/stores.php
@@ -15,8 +15,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $errors[] = 'PIN already exists';
         } else {
-            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder) VALUES (?, ?, ?, ?)');
-            $stmt->execute([$_POST['name'], $_POST['pin'], $_POST['email'], $_POST['folder']]);
+            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_token) VALUES (?, ?, ?, ?, ?)');
+            $stmt->execute([
+                $_POST['name'],
+                $_POST['pin'],
+                $_POST['email'],
+                $_POST['folder'],
+                $_POST['hootsuite_token']
+            ]);
             $success[] = 'Store added successfully';
         }
     }
@@ -76,6 +82,7 @@ include __DIR__.'/header.php';
                         <th>PIN</th>
                         <th>Admin Email</th>
                         <th>Drive Folder ID</th>
+                        <th>Hootsuite Token</th>
                         <th>Uploads</th>
                         <th>Actions</th>
                     </tr>
@@ -94,6 +101,9 @@ include __DIR__.'/header.php';
                                 <?php else: ?>
                                     <span class="text-muted">Auto-create on first upload</span>
                                 <?php endif; ?>
+                            </td>
+                            <td>
+                                <?php echo $s['hootsuite_token'] ? '<span class="badge bg-success">Set</span>' : '<span class="badge bg-secondary">None</span>'; ?>
                             </td>
                             <td>
                                 <span class="badge bg-info"><?php echo $s['upload_count']; ?></span>
@@ -143,6 +153,11 @@ include __DIR__.'/header.php';
                     <label for="folder" class="form-label">Drive Folder ID</label>
                     <input type="text" name="folder" id="folder" class="form-control">
                     <div class="form-text">Leave blank to auto-create on first upload</div>
+                </div>
+                <div class="col-md-6">
+                    <label for="hootsuite_token" class="form-label">Hootsuite Access Token</label>
+                    <input type="text" name="hootsuite_token" id="hootsuite_token" class="form-control">
+                    <div class="form-text">Optional: token used to fetch scheduled posts</div>
                 </div>
                 <div class="col-12">
                     <button class="btn btn-primary" name="add" type="submit">Add Store</button>

--- a/lib/hootsuite.php
+++ b/lib/hootsuite.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Minimal Hootsuite API helper. Currently only fetches scheduled messages.
+ */
+function hootsuite_get_scheduled_posts(string $token): array {
+    if (empty($token)) {
+        return [];
+    }
+
+    $url = 'https://platform.hootsuite.com/v1/messages?state=schedule';
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => [
+            'Authorization: Bearer ' . $token,
+            'Content-Type: application/json'
+        ]
+    ]);
+    $response = curl_exec($ch);
+    if ($response === false) {
+        curl_close($ch);
+        return [];
+    }
+    curl_close($ch);
+    $data = json_decode($response, true);
+    if (!is_array($data) || !isset($data['data'])) {
+        return [];
+    }
+    return $data['data'];
+}

--- a/public/calendar.php
+++ b/public/calendar.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/hootsuite.php';
+
+session_start();
+
+if (!isset($_SESSION['store_id'])) {
+    header('Location: index.php');
+    exit;
+}
+
+$store_id = $_SESSION['store_id'];
+$pdo = get_pdo();
+
+$stmt = $pdo->prepare('SELECT hootsuite_token, name FROM stores WHERE id = ?');
+$stmt->execute([$store_id]);
+$store = $stmt->fetch();
+$store_name = $store['name'];
+$token = $store['hootsuite_token'];
+
+$posts = hootsuite_get_scheduled_posts($token);
+
+include __DIR__.'/header.php';
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h2>Calendar - <?php echo htmlspecialchars($store_name); ?></h2>
+    <a href="index.php" class="btn btn-primary">Back to Upload</a>
+</div>
+
+<?php if (empty($posts)): ?>
+    <div class="alert alert-info">No scheduled posts found.</div>
+<?php else: ?>
+    <div class="table-responsive">
+        <table class="table table-hover">
+            <thead>
+            <tr>
+                <th>Message</th>
+                <th>Scheduled Time</th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($posts as $p): ?>
+                <tr>
+                    <td><?php echo htmlspecialchars($p['text'] ?? ''); ?></td>
+                    <td><?php echo htmlspecialchars($p['scheduledSendTime'] ?? ''); ?></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+<?php endif; ?>
+
+<?php include __DIR__.'/footer.php'; ?>

--- a/public/header.php
+++ b/public/header.php
@@ -44,6 +44,11 @@ if (!isset($_SESSION)) { session_start(); }
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="calendar.php">
+                            <i class="bi bi-calendar-event"></i> Calendar
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="?logout=1">
                             <i class="bi bi-box-arrow-right"></i> Logout
                         </a>

--- a/public/index.php
+++ b/public/index.php
@@ -502,6 +502,9 @@ include __DIR__.'/header.php';
                         <a href="history.php" class="btn btn-primary">
                             <i class="bi bi-clock-history"></i> View Upload History
                         </a>
+                        <a href="calendar.php" class="btn btn-primary">
+                            <i class="bi bi-calendar-event"></i> View Calendar
+                        </a>
                         <a href="?logout=1" class="btn btn-secondary">
                             <i class="bi bi-box-arrow-right"></i> Change Store
                         </a>

--- a/setup.php
+++ b/setup.php
@@ -20,6 +20,7 @@ $queries = [
         pin VARCHAR(50) NOT NULL UNIQUE,
         admin_email VARCHAR(255),
         drive_folder VARCHAR(255),
+        hootsuite_token VARCHAR(255),
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
 
@@ -111,6 +112,14 @@ try {
     $pdo->exec("ALTER TABLE store_messages ADD COLUMN upload_id INT DEFAULT NULL AFTER is_reply");
     $pdo->exec("ALTER TABLE store_messages ADD CONSTRAINT fk_upload_id FOREIGN KEY (upload_id) REFERENCES uploads(id) ON DELETE CASCADE");
     echo "✓ Added upload_id column to store_messages table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+// Add hootsuite_token column to stores table if not exists
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_token VARCHAR(255) AFTER drive_folder");
+    echo "✓ Added hootsuite_token column to stores table\n";
 } catch (PDOException $e) {
     // Column might already exist
 }

--- a/update_database.php
+++ b/update_database.php
@@ -38,5 +38,13 @@ foreach ($defaultSettings as $name => $value) {
     }
 }
 
+// Add hootsuite_token column to stores table
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_token VARCHAR(255) AFTER drive_folder");
+    echo "✓ Added hootsuite_token column to stores table\n";
+} catch (PDOException $e) {
+    echo "• hootsuite_token column might already exist\n";
+}
+
 echo "\n✓ Database update complete!\n";
 ?>


### PR DESCRIPTION
## Summary
- add `hootsuite_token` column to stores table
- expose Hootsuite token field in admin
- show token status in store list
- add calendar link for logged in users and quick actions
- fetch scheduled posts via new helper
- add calendar page

## Testing
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68740030d6448326bbf4743daa5cf9a1