### PR TITLE
Add store contact fields and editing

### DIFF
--- a/admin/stores.php
+++ b/admin/stores.php
@@ -15,13 +15,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $errors[] = 'PIN already exists';
         } else {
-            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_token) VALUES (?, ?, ?, ?, ?)');
+            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_token, first_name, last_name, phone, address) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
             $stmt->execute([
                 $_POST['name'],
                 $_POST['pin'],
                 $_POST['email'],
                 $_POST['folder'],
-                $_POST['hootsuite_token']
+                $_POST['hootsuite_token'],
+                $_POST['first_name'] ?? null,
+                $_POST['last_name'] ?? null,
+                $_POST['phone'] ?? null,
+                $_POST['address'] ?? null
             ]);
             $success[] = 'Store added successfully';
         }
@@ -90,7 +94,7 @@ include __DIR__.'/header.php';
                     <tbody>
                     <?php foreach ($stores as $s): ?>
                         <tr>
-                            <td><strong><?php echo htmlspecialchars($s['name']); ?></strong></td>
+                            <td><strong><a href="edit_store.php?id=<?php echo $s['id']; ?>"><?php echo htmlspecialchars($s['name']); ?></a></strong></td>
                             <td><code><?php echo htmlspecialchars($s['pin']); ?></code></td>
                             <td><?php echo htmlspecialchars($s['admin_email']); ?></td>
                             <td>
@@ -111,6 +115,9 @@ include __DIR__.'/header.php';
                             <td>
                                 <a href="uploads.php?store_id=<?php echo $s['id']; ?>" class="btn btn-sm btn-primary">
                                     View Uploads
+                                </a>
+                                <a href="edit_store.php?id=<?php echo $s['id']; ?>" class="btn btn-sm btn-secondary">
+                                    Edit
                                 </a>
                                 <form method="post" class="d-inline">
                                     <input type="hidden" name="id" value="<?php echo $s['id']; ?>">
@@ -148,6 +155,22 @@ include __DIR__.'/header.php';
                     <label for="email" class="form-label">Admin Email</label>
                     <input type="email" name="email" id="email" class="form-control">
                     <div class="form-text">For notifications specific to this store</div>
+                </div>
+                <div class="col-md-6">
+                    <label for="first_name" class="form-label">First Name</label>
+                    <input type="text" name="first_name" id="first_name" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="last_name" class="form-label">Last Name</label>
+                    <input type="text" name="last_name" id="last_name" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="phone" class="form-label">Phone</label>
+                    <input type="text" name="phone" id="phone" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="address" class="form-label">Address</label>
+                    <input type="text" name="address" id="address" class="form-control">
                 </div>
                 <div class="col-md-6">
                     <label for="folder" class="form-label">Drive Folder ID</label>

--- a/setup.php
+++ b/setup.php
@@ -21,6 +21,10 @@ $queries = [
         admin_email VARCHAR(255),
         drive_folder VARCHAR(255),
         hootsuite_token VARCHAR(255),
+        first_name VARCHAR(100),
+        last_name VARCHAR(100),
+        phone VARCHAR(50),
+        address VARCHAR(255),
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
 
@@ -120,6 +124,35 @@ try {
 try {
     $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_token VARCHAR(255) AFTER drive_folder");
     echo "✓ Added hootsuite_token column to stores table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+// Additional store contact columns
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN first_name VARCHAR(100) AFTER hootsuite_token");
+    echo "✓ Added first_name column to stores table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN last_name VARCHAR(100) AFTER first_name");
+    echo "✓ Added last_name column to stores table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN phone VARCHAR(50) AFTER last_name");
+    echo "✓ Added phone column to stores table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN address VARCHAR(255) AFTER phone");
+    echo "✓ Added address column to stores table\n";
 } catch (PDOException $e) {
     // Column might already exist
 }

--- a/update_database.php
+++ b/update_database.php
@@ -46,5 +46,34 @@ try {
     echo "• hootsuite_token column might already exist\n";
 }
 
+// New contact columns for stores
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN first_name VARCHAR(100) AFTER hootsuite_token");
+    echo "✓ Added first_name column to stores table\n";
+} catch (PDOException $e) {
+    echo "• first_name column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN last_name VARCHAR(100) AFTER first_name");
+    echo "✓ Added last_name column to stores table\n";
+} catch (PDOException $e) {
+    echo "• last_name column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN phone VARCHAR(50) AFTER last_name");
+    echo "✓ Added phone column to stores table\n";
+} catch (PDOException $e) {
+    echo "• phone column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN address VARCHAR(255) AFTER phone");
+    echo "✓ Added address column to stores table\n";
+} catch (PDOException $e) {
+    echo "• address column might already exist\n";
+}
+
 echo "\n✓ Database update complete!\n";
 ?>


### PR DESCRIPTION
## Summary
- extend stores table with contact info
- support updating DB with new fields
- allow adding contact info when creating stores
- allow editing store information via new page
- link store names to edit page and add "Edit" button in actions

## Testing
- `php -l setup.php`
- `php -l update_database.php`
- `php -l admin/stores.php`
- `php -l admin/edit_store.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687407c03b588326962dc0a8c374beeb