### PR TITLE
Fix admin user page DB column

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Standalone PHP application for uploading store photos/videos to Google Drive.
 3. Upload the project files to your PHP host.
 4. Access `public/index.php` for store uploads and `admin/login.php` for the admin portal.
 
+### Upgrading
+
+If you update the application and encounter errors related to missing database columns,
+run `php update_database.php` to apply the latest schema changes.
+
 ### Google Login
 
 Fill in the `google_oauth` settings in `config.php` to enable "Login with Google" on the admin login page. The email returned by Google must match a username in the `users` table.

--- a/update_database.php
+++ b/update_database.php
@@ -90,5 +90,13 @@ try {
     echo "• address column might already exist\n";
 }
 
+// Ensure admin users table has a created_at column
+try {
+    $pdo->exec("ALTER TABLE users ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP");
+    echo "✓ Added created_at column to users table\n";
+} catch (PDOException $e) {
+    echo "• created_at column might already exist\n";
+}
+
 echo "\n✓ Database update complete!\n";
 ?>


### PR DESCRIPTION
## Summary
- update README with upgrade notes
- add `created_at` column update for existing users table

## Testing
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687412286bcc8326a346d6e4d7f588ef