### PR TITLE
Add admin fields and consistent date format

### DIFF
--- a/admin/articles.php
+++ b/admin/articles.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
+require_once __DIR__.'/../lib/helpers.php';
 require_login();
 $pdo = get_pdo();
 
@@ -252,7 +253,7 @@ include __DIR__.'/header.php';
                                         <?php echo ucfirst($article['status']); ?>
                                     </span>
                                 </td>
-                                <td><?php echo date('Y-m-d', strtotime($article['created_at'])); ?></td>
+                                <td><?php echo format_ts($article['created_at']); ?></td>
                                 <td class="article-excerpt">
                                     <?php
                                     $excerpt = $article['excerpt'] ?: strip_tags($article['content']);

--- a/admin/edit_user.php
+++ b/admin/edit_user.php
@@ -1,0 +1,93 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/auth.php';
+require_once __DIR__.'/../lib/helpers.php';
+require_login();
+$pdo = get_pdo();
+
+$id = $_GET['id'] ?? 0;
+$stmt = $pdo->prepare('SELECT * FROM users WHERE id = ?');
+$stmt->execute([$id]);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$user) {
+    header('Location: users.php');
+    exit;
+}
+
+$errors = [];
+$success = false;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_user'])) {
+    $username = trim($_POST['username'] ?? '');
+    $first = trim($_POST['first_name'] ?? '');
+    $last = trim($_POST['last_name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    if ($username === '' || $email === '') {
+        $errors[] = 'Username and email are required';
+    } else {
+        $password = $_POST['password'] ?? '';
+        if ($password !== '') {
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            $stmt = $pdo->prepare('UPDATE users SET username=?, password=?, first_name=?, last_name=?, email=? WHERE id=?');
+            $stmt->execute([$username, $hash, $first ?: null, $last ?: null, $email, $id]);
+        } else {
+            $stmt = $pdo->prepare('UPDATE users SET username=?, first_name=?, last_name=?, email=? WHERE id=?');
+            $stmt->execute([$username, $first ?: null, $last ?: null, $email, $id]);
+        }
+        $success = true;
+        $stmt = $pdo->prepare('SELECT * FROM users WHERE id = ?');
+        $stmt->execute([$id]);
+        $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+}
+
+$active = 'users';
+include __DIR__.'/header.php';
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h4>Edit User</h4>
+    <a href="users.php" class="btn btn-sm btn-outline-secondary">Back</a>
+</div>
+<?php foreach ($errors as $e): ?>
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        <?php echo htmlspecialchars($e); ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+<?php endforeach; ?>
+<?php if ($success): ?>
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        User updated successfully
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+<?php endif; ?>
+<div class="card">
+    <div class="card-body">
+        <form method="post" class="row g-3">
+            <div class="col-md-6">
+                <label for="username" class="form-label">Username</label>
+                <input type="text" name="username" id="username" class="form-control" required value="<?php echo htmlspecialchars($user['username']); ?>">
+            </div>
+            <div class="col-md-6">
+                <label for="password" class="form-label">Password</label>
+                <input type="password" name="password" id="password" class="form-control" placeholder="Leave blank to keep same">
+            </div>
+            <div class="col-md-6">
+                <label for="first_name" class="form-label">First Name</label>
+                <input type="text" name="first_name" id="first_name" class="form-control" value="<?php echo htmlspecialchars($user['first_name']); ?>">
+            </div>
+            <div class="col-md-6">
+                <label for="last_name" class="form-label">Last Name</label>
+                <input type="text" name="last_name" id="last_name" class="form-control" value="<?php echo htmlspecialchars($user['last_name']); ?>">
+            </div>
+            <div class="col-md-6">
+                <label for="email" class="form-label">Email</label>
+                <input type="email" name="email" id="email" class="form-control" required value="<?php echo htmlspecialchars($user['email']); ?>">
+            </div>
+            <div class="col-12">
+                <button class="btn btn-primary" name="save_user" type="submit">Save Changes</button>
+            </div>
+        </form>
+    </div>
+</div>
+<?php include __DIR__.'/footer.php'; ?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
+require_once __DIR__.'/../lib/helpers.php';
 require_login();
 $pdo = get_pdo();
 
@@ -167,7 +168,7 @@ include __DIR__.'/header.php';
                                                  alt="<?php echo htmlspecialchars($upload['filename']); ?>"
                                                  loading="lazy">
                                         </td>
-                                        <td><?php echo date('H:i', strtotime($upload['created_at'])); ?></td>
+                                        <td><?php echo format_ts($upload['created_at']); ?></td>
                                         <td><?php echo htmlspecialchars($upload['store_name']); ?></td>
                                         <td><?php echo htmlspecialchars($upload['filename']); ?></td>
                                         <td>
@@ -222,7 +223,7 @@ include __DIR__.'/header.php';
                                             <?php echo ucfirst($article['status']); ?>
                                         </span>
                                         </td>
-                                        <td><?php echo date('m/d H:i', strtotime($article['created_at'])); ?></td>
+                                        <td><?php echo format_ts($article['created_at']); ?></td>
                                         <td>
                                             <a href="articles.php" class="btn btn-sm btn-primary">Review</a>
                                         </td>

--- a/admin/messages.php
+++ b/admin/messages.php
@@ -2,6 +2,7 @@
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
 require_once __DIR__.'/../lib/config.php';
+require_once __DIR__.'/../lib/helpers.php';
 require_login();
 $pdo = get_pdo();
 $config = get_config();
@@ -181,7 +182,7 @@ include __DIR__.'/header.php';
                                                 <span class="badge bg-warning text-dark">All Stores</span>
                                             <?php endif; ?>
                                         </h6>
-                                        <small><?php echo date('Y-m-d H:i', strtotime($msg['created_at'])); ?></small>
+                                        <small><?php echo format_ts($msg['created_at']); ?></small>
                                     </div>
                                     <p class="mb-1"><?php echo nl2br(htmlspecialchars($msg['message'])); ?></p>
                                     <a href="?delete=<?php echo $msg['id']; ?>"

--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -2,6 +2,7 @@
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
 require_once __DIR__.'/../lib/drive.php';
+require_once __DIR__.'/../lib/helpers.php';
 require_login();
 $pdo = get_pdo();
 
@@ -227,7 +228,7 @@ include __DIR__.'/header.php';
                         <p class="card-text">
                             <strong class="text-primary"><?php echo htmlspecialchars($r['store_name']); ?></strong><br>
                             <small class="text-muted">
-                                <?php echo date('Y-m-d H:i', strtotime($r['created_at'])); ?><br>
+                                <?php echo format_ts($r['created_at']); ?><br>
                                 <?php echo number_format($r['size'] / 1024 / 1024, 2); ?> MB • <?php echo htmlspecialchars(explode('/', $r['mime'])[0]); ?>
                             </small>
                         </p>

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
+require_once __DIR__.'/../lib/helpers.php';
 require_login();
 $pdo = get_pdo();
 
@@ -11,13 +12,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['add'])) {
         $username = trim($_POST['username'] ?? '');
         $password = $_POST['password'] ?? '';
-        if ($username === '' || $password === '') {
-            $errors[] = 'Username and password are required';
+        $first = trim($_POST['first_name'] ?? '');
+        $last = trim($_POST['last_name'] ?? '');
+        $email = trim($_POST['email'] ?? '');
+        if ($username === '' || $password === '' || $email === '') {
+            $errors[] = 'Username, password and email are required';
         } else {
             $hash = password_hash($password, PASSWORD_DEFAULT);
             try {
-                $stmt = $pdo->prepare('INSERT INTO users (username, password) VALUES (?, ?)');
-                $stmt->execute([$username, $hash]);
+                $stmt = $pdo->prepare('INSERT INTO users (username, password, first_name, last_name, email) VALUES (?, ?, ?, ?, ?)');
+                $stmt->execute([$username, $hash, $first ?: null, $last ?: null, $email]);
                 $success[] = 'User added';
             } catch (PDOException $e) {
                 $errors[] = 'User already exists';
@@ -30,7 +34,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
-$users = $pdo->query('SELECT id, username, created_at FROM users ORDER BY username')->fetchAll(PDO::FETCH_ASSOC);
+$users = $pdo->query('SELECT id, username, first_name, last_name, email, created_at FROM users ORDER BY username')->fetchAll(PDO::FETCH_ASSOC);
 
 $active = 'users';
 include __DIR__.'/header.php';
@@ -58,6 +62,8 @@ include __DIR__.'/header.php';
                     <thead>
                     <tr>
                         <th>Username</th>
+                        <th>Name</th>
+                        <th>Email</th>
                         <th>Created</th>
                         <th>Actions</th>
                     </tr>
@@ -66,8 +72,11 @@ include __DIR__.'/header.php';
                     <?php foreach ($users as $u): ?>
                         <tr>
                             <td><?php echo htmlspecialchars($u['username']); ?></td>
-                            <td><?php echo htmlspecialchars($u['created_at']); ?></td>
+                            <td><?php echo htmlspecialchars(trim(($u['first_name'] ?? '') . ' ' . ($u['last_name'] ?? ''))); ?></td>
+                            <td><?php echo htmlspecialchars($u['email']); ?></td>
+                            <td><?php echo format_ts($u['created_at']); ?></td>
                             <td>
+                                <a href="edit_user.php?id=<?php echo $u['id']; ?>" class="btn btn-sm btn-secondary">Edit</a>
                                 <form method="post" class="d-inline">
                                     <input type="hidden" name="id" value="<?php echo $u['id']; ?>">
                                     <button class="btn btn-sm btn-danger" name="delete" onclick="return confirm('Delete this user?')">Delete</button>
@@ -94,6 +103,18 @@ include __DIR__.'/header.php';
                 <div class="col-md-6">
                     <label for="password" class="form-label">Password</label>
                     <input type="password" name="password" id="password" class="form-control" required>
+                </div>
+                <div class="col-md-6">
+                    <label for="first_name" class="form-label">First Name</label>
+                    <input type="text" name="first_name" id="first_name" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="last_name" class="form-label">Last Name</label>
+                    <input type="text" name="last_name" id="last_name" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="email" class="form-label">Email</label>
+                    <input type="email" name="email" id="email" class="form-control" required>
                 </div>
                 <div class="col-12">
                     <button class="btn btn-primary" name="add" type="submit">Add User</button>

--- a/admin/view_article_admin.php
+++ b/admin/view_article_admin.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
+require_once __DIR__.'/../lib/helpers.php';
 require_login();
 
 $article_id = $_GET['id'] ?? 0;
@@ -28,9 +29,9 @@ if (!$article) {
 }
 
 // Format dates
-$article['created_at'] = date('F j, Y g:i A', strtotime($article['created_at']));
+$article['created_at'] = format_ts($article['created_at']);
 if ($article['updated_at']) {
-    $article['updated_at'] = date('F j, Y g:i A', strtotime($article['updated_at']));
+    $article['updated_at'] = format_ts($article['updated_at']);
 }
 
 // Get status class for badge

--- a/cmuploader.sql
+++ b/cmuploader.sql
@@ -212,6 +212,9 @@ CREATE TABLE `users` (
   `id` int(11) NOT NULL,
   `username` varchar(50) NOT NULL,
   `password` varchar(255) NOT NULL,
+  `first_name` varchar(100) DEFAULT NULL,
+  `last_name` varchar(100) DEFAULT NULL,
+  `email` varchar(255) NOT NULL,
   `created_at` timestamp NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
@@ -219,8 +222,8 @@ CREATE TABLE `users` (
 -- Dumping data for table `users`
 --
 
-INSERT INTO `users` (`id`, `username`, `password`, `created_at`) VALUES
-(1, 'admin', '$2y$10$aIKmnAZxd/D5WdCHFMmto.tMsL3os10L8yUC5W4XMSdeKee/8vGpi', '2025-07-13 20:14:56');
+INSERT INTO `users` (`id`, `username`, `password`, `first_name`, `last_name`, `email`, `created_at`) VALUES
+(1, 'admin', '$2y$10$aIKmnAZxd/D5WdCHFMmto.tMsL3os10L8yUC5W4XMSdeKee/8vGpi', 'Admin', '', 'admin@example.com', '2025-07-13 20:14:56');
 
 --
 -- Indexes for dumped tables

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -1,0 +1,7 @@
+<?php
+function format_ts($time): string {
+    if ($time === null || $time === '') {
+        return '';
+    }
+    return date('n-j-y g:ia', strtotime($time));
+}

--- a/public/articles.php
+++ b/public/articles.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
+require_once __DIR__.'/../lib/helpers.php';
 
 session_start();
 
@@ -268,7 +269,7 @@ include __DIR__.'/header.php';
 
                             <div class="d-flex justify-content-between align-items-center">
                                 <small class="text-muted">
-                                    <i class="bi bi-calendar"></i> <?php echo date('M d, Y', strtotime($article['created_at'])); ?>
+                                    <i class="bi bi-calendar"></i> <?php echo format_ts($article['created_at']); ?>
                                 </small>
                                 <div>
                                     <button class="btn btn-sm btn-outline-primary" onclick="viewArticle(<?php echo $article['id']; ?>)">

--- a/public/calendar.php
+++ b/public/calendar.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/hootsuite.php';
+require_once __DIR__.'/../lib/helpers.php';
 
 session_start();
 

--- a/public/history.php
+++ b/public/history.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
+require_once __DIR__.'/../lib/helpers.php';
 
 session_start();
 
@@ -106,7 +107,7 @@ include __DIR__.'/header.php';
                              alt="<?php echo htmlspecialchars($upload['filename']); ?>"
                              loading="lazy">
                     </td>
-                    <td><?php echo date('Y-m-d H:i', strtotime($upload['created_at'])); ?></td>
+                    <td><?php echo format_ts($upload['created_at']); ?></td>
                     <td><?php echo htmlspecialchars($upload['filename']); ?></td>
                     <td><?php echo htmlspecialchars($upload['description']); ?></td>
                     <td>

--- a/public/index.php
+++ b/public/index.php
@@ -2,6 +2,7 @@
 // Store uploader main page
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/drive.php';
+require_once __DIR__.'/../lib/helpers.php';
 
 $config = get_config();
 
@@ -433,7 +434,7 @@ include __DIR__.'/header.php';
             <div class="mb-2">
                 <strong>Re: <?php echo htmlspecialchars($reply['filename']); ?></strong><br>
                 <?php echo nl2br(htmlspecialchars($reply['message'])); ?>
-                <small class="text-muted d-block"><?php echo date('Y-m-d H:i', strtotime($reply['created_at'])); ?></small>
+                <small class="text-muted d-block"><?php echo format_ts($reply['created_at']); ?></small>
             </div>
         <?php endforeach; ?>
         <button type="button" class="btn-close" data-bs-dismiss="alert"></button>

--- a/public/view_article.php
+++ b/public/view_article.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/helpers.php';
 
 session_start();
 
@@ -30,9 +31,9 @@ if (!$article) {
 }
 
 // Format the response
-$article['created_at'] = date('F j, Y g:i A', strtotime($article['created_at']));
+$article['created_at'] = format_ts($article['created_at']);
 if ($article['updated_at']) {
-    $article['updated_at'] = date('F j, Y g:i A', strtotime($article['updated_at']));
+    $article['updated_at'] = format_ts($article['updated_at']);
 }
 
 echo json_encode([

--- a/setup.php
+++ b/setup.php
@@ -33,6 +33,9 @@ $queries = [
         id INT AUTO_INCREMENT PRIMARY KEY,
         username VARCHAR(50) NOT NULL UNIQUE,
         password VARCHAR(255) NOT NULL,
+        first_name VARCHAR(100),
+        last_name VARCHAR(100),
+        email VARCHAR(255) NOT NULL,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
 
@@ -167,11 +170,35 @@ try {
     // Column might already exist
 }
 
+// Ensure users table has new contact columns
+try {
+    $pdo->exec("ALTER TABLE users ADD COLUMN first_name VARCHAR(100) AFTER password");
+    echo "✓ Added first_name column to users table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+try {
+    $pdo->exec("ALTER TABLE users ADD COLUMN last_name VARCHAR(100) AFTER first_name");
+    echo "✓ Added last_name column to users table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+try {
+    $pdo->exec("ALTER TABLE users ADD COLUMN email VARCHAR(255) AFTER last_name");
+    echo "✓ Added email column to users table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
 // Create default admin user
 $username = 'admin';
 $password = password_hash($config['admin_password'], PASSWORD_DEFAULT);
+$email = $config['notification_email'] ?? 'admin@example.com';
 try {
-    $pdo->prepare("INSERT IGNORE INTO users (username, password) VALUES (?, ?)")->execute([$username, $password]);
+    $pdo->prepare("INSERT IGNORE INTO users (username, password, first_name, last_name, email) VALUES (?, ?, ?, ?, ?)")
+        ->execute([$username, $password, 'Admin', '', $email]);
     echo "✓ Default admin user created/verified\n";
 } catch (PDOException $e) {
     echo "✗ Error creating admin user: " . $e->getMessage() . "\n";

--- a/update_database.php
+++ b/update_database.php
@@ -90,12 +90,30 @@ try {
     echo "• address column might already exist\n";
 }
 
-// Ensure admin users table has a created_at column
+// Ensure admin users table has required columns
 try {
     $pdo->exec("ALTER TABLE users ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP");
     echo "✓ Added created_at column to users table\n";
 } catch (PDOException $e) {
     echo "• created_at column might already exist\n";
+}
+try {
+    $pdo->exec("ALTER TABLE users ADD COLUMN first_name VARCHAR(100) AFTER password");
+    echo "✓ Added first_name column to users table\n";
+} catch (PDOException $e) {
+    echo "• first_name column might already exist\n";
+}
+try {
+    $pdo->exec("ALTER TABLE users ADD COLUMN last_name VARCHAR(100) AFTER first_name");
+    echo "✓ Added last_name column to users table\n";
+} catch (PDOException $e) {
+    echo "• last_name column might already exist\n";
+}
+try {
+    $pdo->exec("ALTER TABLE users ADD COLUMN email VARCHAR(255) AFTER last_name");
+    echo "✓ Added email column to users table\n";
+} catch (PDOException $e) {
+    echo "• email column might already exist\n";
 }
 
 echo "\n✓ Database update complete!\n";


### PR DESCRIPTION
## Summary
- store extra info for admin users (first name, last name, email)
- allow editing admin user details
- add global helper to format timestamps
- apply new format across UI
- update database setup and upgrade scripts

## Testing
- `php -l lib/helpers.php`
- `php -l admin/users.php`
- `php -l admin/edit_user.php`
- `php -l admin/index.php`
- `php -l admin/messages.php`
- `php -l admin/uploads.php`
- `php -l admin/articles.php`
- `php -l admin/view_article_admin.php`
- `php -l public/history.php`
- `php -l public/index.php`
- `php -l public/articles.php`
- `php -l public/view_article.php`
- `php -l public/calendar.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687414b279b88326a32e2bf48970d93e