### PR TITLE
Add names to store users

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Standalone PHP application for uploading store photos/videos to Google Drive.
 
 If you update the application and encounter errors related to missing database columns,
 run `php update_database.php` to apply the latest schema changes.
+This includes the new `first_name` and `last_name` columns for store users.
 
 ### Google Login
 

--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -49,12 +49,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     } elseif (isset($_POST['add_user'])) {
         $email = trim($_POST['user_email']);
+        $first = trim($_POST['user_first_name'] ?? '');
+        $last = trim($_POST['user_last_name'] ?? '');
         if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
             try {
-                $stmt = $pdo->prepare('INSERT INTO store_users (store_id, email) VALUES (?, ?)');
-                $stmt->execute([$id, $email]);
+                $stmt = $pdo->prepare('INSERT INTO store_users (store_id, email, first_name, last_name) VALUES (?, ?, ?, ?)');
+                $stmt->execute([$id, $email, $first ?: null, $last ?: null]);
                 $success = true;
-                $store_users[] = ['id' => $pdo->lastInsertId(), 'email' => $email];
+                $store_users[] = ['id' => $pdo->lastInsertId(), 'email' => $email, 'first_name' => $first, 'last_name' => $last];
             } catch (PDOException $e) {
                 $errors[] = 'User already exists for this store';
             }
@@ -144,11 +146,17 @@ include __DIR__.'/header.php';
         <ul class="list-group mb-3">
             <?php foreach ($store_users as $u): ?>
                 <li class="list-group-item d-flex justify-content-between align-items-center">
-                    <?php echo htmlspecialchars($u['email']); ?>
-                    <form method="post" class="m-0">
-                        <input type="hidden" name="user_id" value="<?php echo $u['id']; ?>">
-                        <button class="btn btn-sm btn-danger" name="delete_user" onclick="return confirm('Remove this user?')">Remove</button>
-                    </form>
+                    <div>
+                        <?php echo htmlspecialchars(trim(($u['first_name'] ?? '') . ' ' . ($u['last_name'] ?? ''))); ?>
+                        <div class="text-muted small"><?php echo htmlspecialchars($u['email']); ?></div>
+                    </div>
+                    <div>
+                        <a href="edit_store_user.php?store_id=<?php echo $id; ?>&id=<?php echo $u['id']; ?>" class="btn btn-sm btn-secondary me-1">Edit</a>
+                        <form method="post" class="d-inline m-0">
+                            <input type="hidden" name="user_id" value="<?php echo $u['id']; ?>">
+                            <button class="btn btn-sm btn-danger" name="delete_user" onclick="return confirm('Remove this user?')">Remove</button>
+                        </form>
+                    </div>
                 </li>
             <?php endforeach; ?>
             <?php if (empty($store_users)): ?>
@@ -156,10 +164,16 @@ include __DIR__.'/header.php';
             <?php endif; ?>
         </ul>
         <form method="post" class="row g-3">
-            <div class="col-md-6">
-                <input type="email" name="user_email" class="form-control" placeholder="User Email" required>
+            <div class="col-md-4">
+                <input type="text" name="user_first_name" class="form-control" placeholder="First Name">
             </div>
-            <div class="col-md-6">
+            <div class="col-md-4">
+                <input type="text" name="user_last_name" class="form-control" placeholder="Last Name">
+            </div>
+            <div class="col-md-4">
+                <input type="email" name="user_email" class="form-control" placeholder="Email" required>
+            </div>
+            <div class="col-12">
                 <button class="btn btn-secondary" name="add_user" type="submit">Add User</button>
             </div>
         </form>

--- a/admin/edit_store_user.php
+++ b/admin/edit_store_user.php
@@ -1,0 +1,78 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/auth.php';
+require_login();
+$pdo = get_pdo();
+
+$store_id = $_GET['store_id'] ?? 0;
+$id = $_GET['id'] ?? 0;
+
+$stmt = $pdo->prepare('SELECT * FROM store_users WHERE id=? AND store_id=?');
+$stmt->execute([$id, $store_id]);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$user) {
+    header('Location: edit_store.php?id=' . urlencode($store_id));
+    exit;
+}
+
+$errors = [];
+$success = false;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_user'])) {
+    $email = trim($_POST['email'] ?? '');
+    $first = trim($_POST['first_name'] ?? '');
+    $last = trim($_POST['last_name'] ?? '');
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Valid email is required';
+    } else {
+        $stmt = $pdo->prepare('UPDATE store_users SET email=?, first_name=?, last_name=? WHERE id=? AND store_id=?');
+        $stmt->execute([$email, $first ?: null, $last ?: null, $id, $store_id]);
+        $success = true;
+        $stmt = $pdo->prepare('SELECT * FROM store_users WHERE id=? AND store_id=?');
+        $stmt->execute([$id, $store_id]);
+        $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+}
+
+$active = 'stores';
+include __DIR__.'/header.php';
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h4>Edit Store User</h4>
+    <a href="edit_store.php?id=<?php echo $store_id; ?>" class="btn btn-sm btn-outline-secondary">Back</a>
+</div>
+<?php foreach ($errors as $e): ?>
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        <?php echo htmlspecialchars($e); ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+<?php endforeach; ?>
+<?php if ($success): ?>
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        User updated successfully
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+<?php endif; ?>
+<div class="card">
+    <div class="card-body">
+        <form method="post" class="row g-3">
+            <div class="col-md-6">
+                <label for="first_name" class="form-label">First Name</label>
+                <input type="text" name="first_name" id="first_name" class="form-control" value="<?php echo htmlspecialchars($user['first_name']); ?>">
+            </div>
+            <div class="col-md-6">
+                <label for="last_name" class="form-label">Last Name</label>
+                <input type="text" name="last_name" id="last_name" class="form-control" value="<?php echo htmlspecialchars($user['last_name']); ?>">
+            </div>
+            <div class="col-md-6">
+                <label for="email" class="form-label">Email</label>
+                <input type="email" name="email" id="email" class="form-control" required value="<?php echo htmlspecialchars($user['email']); ?>">
+            </div>
+            <div class="col-12">
+                <button class="btn btn-primary" name="save_user" type="submit">Save Changes</button>
+            </div>
+        </form>
+    </div>
+</div>
+<?php include __DIR__.'/footer.php'; ?>

--- a/cmuploader.sql
+++ b/cmuploader.sql
@@ -150,6 +150,8 @@ CREATE TABLE `store_users` (
   `id` int(11) NOT NULL,
   `store_id` int(11) NOT NULL,
   `email` varchar(255) NOT NULL,
+  `first_name` varchar(100) DEFAULT NULL,
+  `last_name` varchar(100) DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 

--- a/setup.php
+++ b/setup.php
@@ -44,6 +44,8 @@ $queries = [
         id INT AUTO_INCREMENT PRIMARY KEY,
         store_id INT NOT NULL,
         email VARCHAR(255) NOT NULL,
+        first_name VARCHAR(100),
+        last_name VARCHAR(100),
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         UNIQUE KEY store_email_unique (store_id, email),
         FOREIGN KEY (store_id) REFERENCES stores(id) ON DELETE CASCADE
@@ -166,6 +168,21 @@ try {
 try {
     $pdo->exec("ALTER TABLE stores ADD COLUMN address VARCHAR(255) AFTER phone");
     echo "✓ Added address column to stores table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+// Ensure store_users table has name columns
+try {
+    $pdo->exec("ALTER TABLE store_users ADD COLUMN first_name VARCHAR(100) AFTER email");
+    echo "✓ Added first_name column to store_users table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+try {
+    $pdo->exec("ALTER TABLE store_users ADD COLUMN last_name VARCHAR(100) AFTER first_name");
+    echo "✓ Added last_name column to store_users table\n";
 } catch (PDOException $e) {
     // Column might already exist
 }

--- a/update_database.php
+++ b/update_database.php
@@ -44,6 +44,8 @@ try {
         id INT AUTO_INCREMENT PRIMARY KEY,
         store_id INT NOT NULL,
         email VARCHAR(255) NOT NULL,
+        first_name VARCHAR(100),
+        last_name VARCHAR(100),
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         UNIQUE KEY store_email_unique (store_id, email),
         FOREIGN KEY (store_id) REFERENCES stores(id) ON DELETE CASCADE
@@ -51,6 +53,21 @@ try {
     echo "✓ Created store_users table\n";
 } catch (PDOException $e) {
     echo "✗ Error creating store_users table: " . $e->getMessage() . "\n";
+}
+
+// Ensure store_users table has name columns
+try {
+    $pdo->exec("ALTER TABLE store_users ADD COLUMN first_name VARCHAR(100) AFTER email");
+    echo "✓ Added first_name column to store_users table\n";
+} catch (PDOException $e) {
+    echo "• first_name column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE store_users ADD COLUMN last_name VARCHAR(100) AFTER first_name");
+    echo "✓ Added last_name column to store_users table\n";
+} catch (PDOException $e) {
+    echo "• last_name column might already exist\n";
 }
 
 // Add hootsuite_token column to stores table


### PR DESCRIPTION
## Summary
- add first/last name columns to store_users table
- include migration logic for those columns
- show names in Store Users list
- allow adding names for new store users
- provide editing page for store users
- document new upgrade step

## Testing
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68741993637083268fbfd9874d4a5f25