### PR TITLE
Enhance admin UI and content status

### DIFF
--- a/admin/header.php
+++ b/admin/header.php
@@ -46,12 +46,15 @@ if (!isset($active)) { $active = ''; }
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 <li class="nav-item"><a class="nav-link<?php if($active==='dashboard') echo ' active'; ?>" href="index.php">Dashboard</a></li>
                 <li class="nav-item"><a class="nav-link<?php if($active==='stores') echo ' active'; ?>" href="stores.php">Stores</a></li>
-                <li class="nav-item"><a class="nav-link<?php if($active==='uploads') echo ' active'; ?>" href="uploads.php">Uploads</a></li>
+                <li class="nav-item"><a class="nav-link<?php if($active==='uploads') echo ' active'; ?>" href="uploads.php">Content Review</a></li>
                 <li class="nav-item"><a class="nav-link<?php if($active==='messages') echo ' active'; ?>" href="messages.php">Messages</a></li>
                 <li class="nav-item"><a class="nav-link<?php if($active==='settings') echo ' active'; ?>" href="settings.php">Settings</a></li>
                 <li class="nav-item"><a class="nav-link<?php if($active==='users') echo ' active'; ?>" href="users.php">Users</a></li>
-                <li class="nav-item"><a class="nav-link" href="logout.php">Logout</a></li>
             </ul>
+            <div class="ms-auto text-end small text-white">
+                Logged in as: <?php echo htmlspecialchars($_SESSION['username'] ?? ''); ?><br>
+                <a href="logout.php" class="text-white text-decoration-none">Logout</a>
+            </div>
         </div>
     </div>
 </nav>

--- a/admin/index.php
+++ b/admin/index.php
@@ -155,6 +155,10 @@ try {
     // Table might not exist yet
 }
 
+// Recent broadcast messages
+$stmt = $pdo->query("SELECT message, created_at FROM store_messages WHERE store_id IS NULL ORDER BY created_at DESC LIMIT 5");
+$recent_broadcasts = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
 // Active messages count
 try {
     $stmt = $pdo->query('SELECT COUNT(*) FROM store_messages WHERE is_reply = 0 OR is_reply IS NULL');
@@ -345,6 +349,29 @@ include __DIR__.'/header.php';
                     </div>
                 </div>
             <?php endif; ?>
+
+            <!-- Recent Broadcast Messages Card -->
+            <div class="card mt-4">
+                <div class="card-header">
+                    <h5 class="mb-0">Recent Broadcast Messages</h5>
+                </div>
+                <div class="card-body">
+                    <?php if (empty($recent_broadcasts)): ?>
+                        <p class="text-muted">No recent messages</p>
+                    <?php else: ?>
+                        <ul class="list-group list-group-flush">
+                            <?php foreach ($recent_broadcasts as $bm): ?>
+                                <li class="list-group-item d-flex justify-content-between align-items-start">
+                                    <span><?php echo htmlspecialchars($bm['message']); ?></span>
+                                    <small class="text-muted ms-2"><?php echo format_ts($bm['created_at']); ?></small>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+        </div>
         </div>
 
         <div class="col-lg-4">

--- a/public/marketing.php
+++ b/public/marketing.php
@@ -28,6 +28,6 @@ include __DIR__.'/header.php';
         window.addEventListener('resize',resizeFrame);
     </script>
 <?php else: ?>
-    <div class="alert alert-info">No marketing report available.</div>
+    <div class="alert alert-warning">Marketing report not setup yet.</div>
 <?php endif; ?>
 <?php include __DIR__.'/footer.php'; ?>

--- a/update_database.php
+++ b/update_database.php
@@ -140,5 +140,41 @@ try {
     echo "• email column might already exist\n";
 }
 
+// Create upload_statuses table
+try {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS upload_statuses (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(100) NOT NULL,
+        color VARCHAR(20) NOT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+    echo "✓ Created upload_statuses table\n";
+} catch (PDOException $e) {
+    echo "✗ Error creating upload_statuses table: " . $e->getMessage() . "\n";
+}
+
+// Add status_id column to uploads
+try {
+    $pdo->exec("ALTER TABLE uploads ADD COLUMN status_id INT DEFAULT NULL AFTER drive_id");
+    $pdo->exec("ALTER TABLE uploads ADD CONSTRAINT fk_status_id FOREIGN KEY (status_id) REFERENCES upload_statuses(id)");
+    echo "✓ Added status_id column to uploads table\n";
+} catch (PDOException $e) {
+    echo "• status_id column might already exist\n";
+}
+
+// Insert default statuses
+$defaultStatuses = [
+    ['Reviewed', '#198754'],
+    ['Pending Submission', '#ffc107'],
+    ['Scheduled', '#0dcaf0']
+];
+foreach ($defaultStatuses as $st) {
+    try {
+        $stmt = $pdo->prepare("INSERT IGNORE INTO upload_statuses (name, color) VALUES (?, ?)");
+        $stmt->execute($st);
+    } catch (PDOException $e) {
+        // ignore
+    }
+}
+
 echo "\n✓ Database update complete!\n";
 ?>


### PR DESCRIPTION
## Summary
- warn user when marketing report isn't configured
- show logged in admin and logout link in header
- add view toggle and status badges for uploads
- query recent broadcast messages on dashboard
- manage upload statuses in settings with color picker
- create DB schema changes for upload statuses

## Testing
- `php -l public/marketing.php`
- `php -l admin/header.php`
- `php -l admin/uploads.php`
- `php -l admin/index.php`
- `php -l admin/settings.php`
- `php -l setup.php`
- `php -l update_database.php`

------
https://chatgpt.com/codex/tasks/task_e_68742a44388c8326adc1657b7074b65d