### PR TITLE
Add upload status history tracking

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -97,6 +97,20 @@ $queries = [
         color VARCHAR(20) NOT NULL
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
 
+    // Upload status history table
+    "CREATE TABLE IF NOT EXISTS upload_status_history (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        upload_id INT NOT NULL,
+        user_id INT NOT NULL,
+        old_status_id INT DEFAULT NULL,
+        new_status_id INT DEFAULT NULL,
+        changed_at DATETIME NOT NULL,
+        FOREIGN KEY (upload_id) REFERENCES uploads(id) ON DELETE CASCADE,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+        INDEX idx_upload_id (upload_id),
+        INDEX idx_changed_at (changed_at)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+
     // Logs table
     "CREATE TABLE IF NOT EXISTS logs (
         id INT AUTO_INCREMENT PRIMARY KEY,

--- a/update_database.php
+++ b/update_database.php
@@ -176,5 +176,24 @@ foreach ($defaultStatuses as $st) {
     }
 }
 
+// Create upload_status_history table
+try {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS upload_status_history (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        upload_id INT NOT NULL,
+        user_id INT NOT NULL,
+        old_status_id INT DEFAULT NULL,
+        new_status_id INT DEFAULT NULL,
+        changed_at DATETIME NOT NULL,
+        FOREIGN KEY (upload_id) REFERENCES uploads(id) ON DELETE CASCADE,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+        INDEX idx_upload_id (upload_id),
+        INDEX idx_changed_at (changed_at)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+    echo "✓ Created upload_status_history table\n";
+} catch (PDOException $e) {
+    echo "✗ Error creating upload_status_history table: " . $e->getMessage() . "\n";
+}
+
 echo "\n✓ Database update complete!\n";
 ?>


### PR DESCRIPTION
## Summary
- show modifier info on upload card
- log upload status changes
- create `upload_status_history` table in setup and update scripts
- tweak upload card border color

## Testing
- `php -l admin/uploads.php`
- `php -l setup.php`
- `php -l update_database.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687436d7530c8326bc66e0876e966796