### PR TITLE
Add sender column and messaging pages

### DIFF
--- a/admin/conversation.php
+++ b/admin/conversation.php
@@ -1,0 +1,82 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/auth.php';
+require_once __DIR__.'/../lib/helpers.php';
+require_login();
+$pdo = get_pdo();
+
+$store_id = intval($_GET['store_id'] ?? 0);
+if (!$store_id) {
+    echo 'Store ID required';
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT name FROM stores WHERE id = ?');
+$stmt->execute([$store_id]);
+$store = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$store) {
+    echo 'Store not found';
+    exit;
+}
+
+if (isset($_GET['load'])) {
+    $s = $pdo->prepare('SELECT sender, message, created_at FROM store_messages WHERE store_id = ? ORDER BY created_at');
+    $s->execute([$store_id]);
+    $msgs = $s->fetchAll(PDO::FETCH_ASSOC);
+    foreach ($msgs as &$m) {
+        $m['created_at'] = format_ts($m['created_at']);
+    }
+    header('Content-Type: application/json');
+    echo json_encode($msgs);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['message'])) {
+    $message = trim($_POST['message']);
+    if ($message !== '') {
+        $ins = $pdo->prepare("INSERT INTO store_messages (store_id, sender, message, created_at) VALUES (?, 'admin', ?, NOW())");
+        $ins->execute([$store_id, $message]);
+    }
+}
+
+$s = $pdo->prepare('SELECT sender, message, created_at FROM store_messages WHERE store_id = ? ORDER BY created_at');
+$s->execute([$store_id]);
+$messages = $s->fetchAll(PDO::FETCH_ASSOC);
+
+$active = 'messages';
+include __DIR__.'/header.php';
+?>
+<h4>Conversation with <?php echo htmlspecialchars($store['name']); ?></h4>
+<div id="messages" class="mb-4">
+    <?php foreach ($messages as $msg): ?>
+        <div class="mb-2">
+            <strong><?php echo $msg['sender'] === 'admin' ? 'Admin' : 'Store'; ?>:</strong>
+            <span><?php echo nl2br(htmlspecialchars($msg['message'])); ?></span>
+            <small class="text-muted ms-2"><?php echo format_ts($msg['created_at']); ?></small>
+        </div>
+    <?php endforeach; ?>
+</div>
+<form method="post">
+    <textarea name="message" class="form-control mb-2" rows="3" required></textarea>
+    <button class="btn btn-primary" type="submit">Send</button>
+</form>
+<script>
+function refreshMessages() {
+    fetch('conversation.php?store_id=<?php echo $store_id; ?>&load=1')
+        .then(r => r.json())
+        .then(data => {
+            const container = document.getElementById('messages');
+            container.innerHTML = '';
+            data.forEach(m => {
+                const div = document.createElement('div');
+                div.className = 'mb-2';
+                div.innerHTML = `<strong>${m.sender === 'admin' ? 'Admin' : 'Store'}:</strong> ` +
+                    m.message.replace(/\n/g,'<br>') +
+                    ` <small class="text-muted ms-2">${m.created_at}</small>`;
+                container.appendChild(div);
+            });
+        });
+}
+setInterval(refreshMessages, 30000);
+</script>
+<?php include __DIR__.'/footer.php'; ?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['quick_message'])) {
             $store_id = null;
         }
 
-        $stmt = $pdo->prepare('INSERT INTO store_messages (store_id, message, created_at) VALUES (?, ?, NOW())');
+        $stmt = $pdo->prepare("INSERT INTO store_messages (store_id, sender, message, created_at) VALUES (?, 'admin', ?, NOW())");
         $stmt->execute([$store_id, $message]);
 
         $emailSettings = [];

--- a/admin/messages.php
+++ b/admin/messages.php
@@ -22,7 +22,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['message'])) {
             $store_id = null; // NULL means global message
         }
 
-        $stmt = $pdo->prepare('INSERT INTO store_messages (store_id, message, created_at) VALUES (?, ?, NOW())');
+        $stmt = $pdo->prepare("INSERT INTO store_messages (store_id, sender, message, created_at) VALUES (?, 'admin', ?, NOW())");
         $stmt->execute([$store_id, $message]);
 
         // Get email settings

--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -51,12 +51,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['reply_message'])) {
         if ($store_id) {
             // Insert reply as a special message
             try {
-                $stmt = $pdo->prepare('INSERT INTO store_messages (store_id, message, is_reply, upload_id, created_at) VALUES (?, ?, 1, ?, NOW())');
+                $stmt = $pdo->prepare("INSERT INTO store_messages (store_id, sender, message, is_reply, upload_id, created_at) VALUES (?, 'admin', ?, 1, ?, NOW())");
                 $stmt->execute([$store_id, $reply_message, $upload_id]);
                 $success = 'Reply sent successfully';
             } catch (PDOException $e) {
                 // If is_reply column doesn't exist, try without it
-                $stmt = $pdo->prepare('INSERT INTO store_messages (store_id, message, created_at) VALUES (?, ?, NOW())');
+                $stmt = $pdo->prepare("INSERT INTO store_messages (store_id, sender, message, created_at) VALUES (?, 'admin', ?, NOW())");
                 $stmt->execute([$store_id, "Re: File - " . $reply_message]);
                 $success = 'Reply sent successfully';
             }

--- a/cmuploader.sql
+++ b/cmuploader.sql
@@ -123,6 +123,7 @@ INSERT INTO `stores` (`id`, `name`, `pin`, `admin_email`, `drive_folder`, `hoots
 CREATE TABLE `store_messages` (
   `id` int(11) NOT NULL,
   `store_id` int(11) DEFAULT NULL,
+  `sender` enum('admin','store') DEFAULT 'admin',
   `message` text NOT NULL,
   `is_reply` tinyint(1) DEFAULT 0,
   `upload_id` int(11) DEFAULT NULL,
@@ -134,12 +135,12 @@ CREATE TABLE `store_messages` (
 -- Dumping data for table `store_messages`
 --
 
-INSERT INTO `store_messages` (`id`, `store_id`, `message`, `is_reply`, `upload_id`, `article_id`, `created_at`) VALUES
-(1, 2, 'Dont forget to create your content.', 0, NULL, NULL, '2025-07-03 04:26:20'),
-(2, 4, 'Where do these messages go?', 0, NULL, NULL, '2025-07-03 13:46:08'),
-(3, 4, 'Please don\'t forget to upload new social content!', 0, NULL, NULL, '2025-07-03 13:49:44'),
-(4, 3, 'Hey there, it\'s Cassandra. Great to see you here! Don\'t forget to upload your content!', 0, NULL, NULL, '2025-07-03 13:52:29'),
-(5, 4, 'Please don\'t forget to upload new social content!', 0, NULL, NULL, '2025-07-03 18:43:53');
+INSERT INTO `store_messages` (`id`, `store_id`, `sender`, `message`, `is_reply`, `upload_id`, `article_id`, `created_at`) VALUES
+(1, 2, 'admin', 'Dont forget to create your content.', 0, NULL, NULL, '2025-07-03 04:26:20'),
+(2, 4, 'admin', 'Where do these messages go?', 0, NULL, NULL, '2025-07-03 13:46:08'),
+(3, 4, 'admin', 'Please don\'t forget to upload new social content!', 0, NULL, NULL, '2025-07-03 13:49:44'),
+(4, 3, 'admin', 'Hey there, it\'s Cassandra. Great to see you here! Don\'t forget to upload your content!', 0, NULL, NULL, '2025-07-03 13:52:29'),
+(5, 4, 'admin', 'Please don\'t forget to upload new social content!', 0, NULL, NULL, '2025-07-03 18:43:53');
 
 -- --------------------------------------------------------
 

--- a/public/messages.php
+++ b/public/messages.php
@@ -1,0 +1,65 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/helpers.php';
+session_start();
+
+if (!isset($_SESSION['store_id'])) {
+    header('Location: index.php');
+    exit;
+}
+
+$pdo = get_pdo();
+$store_id = $_SESSION['store_id'];
+
+if (isset($_GET['load'])) {
+    $stmt = $pdo->prepare("SELECT sender, message, created_at FROM store_messages WHERE store_id = ? ORDER BY created_at");
+    $stmt->execute([$store_id]);
+    $messages = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    foreach ($messages as &$m) {
+        $m['created_at'] = format_ts($m['created_at']);
+    }
+    header('Content-Type: application/json');
+    echo json_encode($messages);
+    exit;
+}
+
+$stmt = $pdo->prepare("SELECT sender, message, created_at FROM store_messages WHERE store_id = ? ORDER BY created_at");
+$stmt->execute([$store_id]);
+$messages = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+include __DIR__.'/header.php';
+?>
+<h2>Conversation</h2>
+<div id="messages" class="mb-4">
+    <?php foreach ($messages as $msg): ?>
+        <div class="mb-2">
+            <strong><?php echo $msg['sender'] === 'admin' ? 'Admin' : 'You'; ?>:</strong>
+            <span><?php echo nl2br(htmlspecialchars($msg['message'])); ?></span>
+            <small class="text-muted ms-2"><?php echo format_ts($msg['created_at']); ?></small>
+        </div>
+    <?php endforeach; ?>
+</div>
+<form method="post" action="send_message.php" id="msgForm">
+    <textarea name="message" class="form-control mb-2" rows="3" required></textarea>
+    <button type="submit" class="btn btn-primary">Send</button>
+</form>
+<script>
+function refreshMessages() {
+    fetch('messages.php?load=1')
+        .then(r => r.json())
+        .then(data => {
+            const container = document.getElementById('messages');
+            container.innerHTML = '';
+            data.forEach(m => {
+                const div = document.createElement('div');
+                div.className = 'mb-2';
+                div.innerHTML = `<strong>${m.sender === 'admin' ? 'Admin' : 'You'}:</strong> ` +
+                    m.message.replace(/\n/g,'<br>') +
+                    ` <small class="text-muted ms-2">${m.created_at}</small>`;
+                container.appendChild(div);
+            });
+        });
+}
+setInterval(refreshMessages, 30000);
+</script>
+<?php include __DIR__.'/footer.php'; ?>

--- a/public/send_message.php
+++ b/public/send_message.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+session_start();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit('Method not allowed');
+}
+
+if (!isset($_SESSION['store_id'])) {
+    http_response_code(403);
+    exit('Not logged in');
+}
+
+$message = trim($_POST['message'] ?? '');
+if ($message === '') {
+    http_response_code(400);
+    exit('Message cannot be empty');
+}
+
+$pdo = get_pdo();
+$stmt = $pdo->prepare("INSERT INTO store_messages (store_id, sender, message, created_at) VALUES (?, 'store', ?, NOW())");
+$stmt->execute([$_SESSION['store_id'], $message]);
+
+if (!empty($_POST['ajax'])) {
+    echo json_encode(['success' => true]);
+} else {
+    header('Location: messages.php');
+}

--- a/setup.php
+++ b/setup.php
@@ -80,6 +80,7 @@ $queries = [
     "CREATE TABLE IF NOT EXISTS store_messages (
         id INT AUTO_INCREMENT PRIMARY KEY,
         store_id INT DEFAULT NULL,
+        sender ENUM('admin','store') DEFAULT 'admin',
         message TEXT NOT NULL,
         is_reply TINYINT(1) DEFAULT 0,
         upload_id INT DEFAULT NULL,
@@ -153,6 +154,13 @@ try {
 try {
     $pdo->exec("ALTER TABLE store_messages ADD COLUMN is_reply TINYINT(1) DEFAULT 0 AFTER message");
     echo "✓ Added is_reply column to store_messages table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+try {
+    $pdo->exec("ALTER TABLE store_messages ADD COLUMN sender ENUM('admin','store') DEFAULT 'admin' AFTER store_id");
+    echo "✓ Added sender column to store_messages table\n";
 } catch (PDOException $e) {
     // Column might already exist
 }

--- a/update_database.php
+++ b/update_database.php
@@ -70,6 +70,14 @@ try {
     echo "• last_name column might already exist\n";
 }
 
+// Add sender column to store_messages table
+try {
+    $pdo->exec("ALTER TABLE store_messages ADD COLUMN sender ENUM('admin','store') DEFAULT 'admin' AFTER store_id");
+    echo "✓ Added sender column to store_messages table\n";
+} catch (PDOException $e) {
+    echo "• sender column might already exist\n";
+}
+
 // Add hootsuite_token column to stores table
 try {
     $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_token VARCHAR(255) AFTER drive_folder");


### PR DESCRIPTION
## Summary
- expand `store_messages` schema with `sender`
- migrate database in `update_database.php`
- record sender when admins post messages
- allow stores to send messages
- add conversation pages with simple polling

## Testing
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68745a7d81f88326a82c8399d79e70fa