### PR TITLE
Improve chat UX

### DIFF
--- a/admin/footer.php
+++ b/admin/footer.php
@@ -1,5 +1,22 @@
 </div>
 <!-- Bootstrap JS from CDN -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
+<script>
+function checkNotifications(){
+    fetch('notifications.php')
+        .then(r=>r.json())
+        .then(d=>{
+            const countEl=document.getElementById('notifyCount');
+            if(d.count>0){
+                countEl.style.display='inline-block';
+                countEl.textContent=d.count;
+            }else{
+                countEl.style.display='none';
+            }
+        });
+}
+setInterval(checkNotifications,10000);
+checkNotifications();
+</script>
 </body>
 </html>

--- a/admin/header.php
+++ b/admin/header.php
@@ -53,7 +53,11 @@ if (!isset($active)) { $active = ''; }
                 <li class="nav-item"><a class="nav-link<?php if($active==='users') echo ' active'; ?>" href="users.php">Users</a></li>
             </ul>
             <div class="ms-auto text-end small text-white">
-                Logged in as: <?php echo htmlspecialchars($_SESSION['username'] ?? ''); ?><br>
+                <span class="position-relative me-2">
+                    <i class="bi bi-bell" id="notifyBell"></i>
+                    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount" style="display:none;">0</span>
+                </span><br>
+                Logged in as: <?php echo htmlspecialchars(trim(($_SESSION['first_name'] ?? '') . ' ' . ($_SESSION['last_name'] ?? ''))); ?><br>
                 <a href="logout.php" class="text-white text-decoration-none">Logout</a>
             </div>
         </div>

--- a/admin/notifications.php
+++ b/admin/notifications.php
@@ -1,0 +1,8 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/auth.php';
+require_login();
+$pdo = get_pdo();
+$count = $pdo->query("SELECT COUNT(*) FROM store_messages WHERE sender='store' AND read_by_admin=0")->fetchColumn();
+header('Content-Type: application/json');
+echo json_encode(['count'=> (int)$count]);

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -50,7 +50,7 @@ function login($username, $password): bool {
     ensure_session();
 
     $pdo = get_pdo();
-    $stmt = $pdo->prepare('SELECT id, password FROM users WHERE username=?');
+    $stmt = $pdo->prepare('SELECT id, password, first_name, last_name FROM users WHERE username=?');
     $stmt->execute([$username]);
     if ($row = $stmt->fetch()) {
         if (password_verify($password, $row['password'])) {
@@ -59,6 +59,8 @@ function login($username, $password): bool {
             $_SESSION['user_id'] = $row['id'];
             $_SESSION['username'] = $username;
             $_SESSION['login_time'] = time();
+            $_SESSION['first_name'] = $row['first_name'] ?? '';
+            $_SESSION['last_name'] = $row['last_name'] ?? '';
 
             return true;
         }
@@ -89,13 +91,15 @@ function login_with_google_email($email): bool {
     ensure_session();
 
     $pdo = get_pdo();
-    $stmt = $pdo->prepare('SELECT id FROM users WHERE username=?');
+    $stmt = $pdo->prepare('SELECT id, first_name, last_name FROM users WHERE username=?');
     $stmt->execute([$email]);
     if ($row = $stmt->fetch()) {
         session_regenerate_id(true);
         $_SESSION['user_id'] = $row['id'];
         $_SESSION['username'] = $email;
         $_SESSION['login_time'] = time();
+        $_SESSION['first_name'] = $row['first_name'] ?? '';
+        $_SESSION['last_name'] = $row['last_name'] ?? '';
         return true;
     }
     return false;

--- a/public/footer.php
+++ b/public/footer.php
@@ -1,5 +1,22 @@
 </div>
 <!-- Bootstrap JS from CDN -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
+<script>
+function checkNotifications(){
+    fetch('notifications.php')
+        .then(r=>r.json())
+        .then(d=>{
+            const el=document.getElementById('notifyCount');
+            if(el){
+                if(d.count>0){
+                    el.style.display='inline-block';
+                    el.textContent=d.count;
+                }else{el.style.display='none';}
+            }
+        });
+}
+setInterval(checkNotifications,10000);
+checkNotifications();
+</script>
 </body>
 </html>

--- a/public/header.php
+++ b/public/header.php
@@ -53,9 +53,10 @@ if (!isset($_SESSION)) { session_start(); }
                             <i class="bi bi-graph-up"></i> Marketing Report
                         </a>
                     </li>
-                    <li class="nav-item">
+                    <li class="nav-item position-relative">
                         <a class="nav-link" href="messages.php">
                             <i class="bi bi-chat-dots"></i> Chat
+                            <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount" style="display:none;">0</span>
                         </a>
                     </li>
                     <li class="nav-item">

--- a/public/index.php
+++ b/public/index.php
@@ -57,7 +57,7 @@ if (!$isLoggedIn) {
         $email = trim($_POST['email']);
         if ($pin !== '' && $email !== '') {
             $pdo = get_pdo();
-            $stmt = $pdo->prepare('SELECT s.* FROM stores s JOIN store_users u ON u.store_id = s.id WHERE s.pin = ? AND u.email = ?');
+            $stmt = $pdo->prepare('SELECT s.*, u.first_name AS ufname, u.last_name AS ulname FROM stores s JOIN store_users u ON u.store_id = s.id WHERE s.pin = ? AND u.email = ?');
             $stmt->execute([$pin, $email]);
             if ($store = $stmt->fetch()) {
                 session_regenerate_id(true);
@@ -65,6 +65,8 @@ if (!$isLoggedIn) {
                 $_SESSION['store_pin'] = $pin;
                 $_SESSION['store_name'] = $store['name'];
                 $_SESSION['store_user_email'] = $email;
+                $_SESSION['store_first_name'] = $store['ufname'] ?? '';
+                $_SESSION['store_last_name'] = $store['ulname'] ?? '';
                 header('Location: index.php');
                 exit;
             } else {

--- a/public/messages.php
+++ b/public/messages.php
@@ -12,39 +12,68 @@ $pdo = get_pdo();
 $store_id = $_SESSION['store_id'];
 
 if (isset($_GET['load'])) {
-    $stmt = $pdo->prepare("SELECT sender, message, created_at FROM store_messages WHERE store_id = ? ORDER BY created_at");
+    $stmt = $pdo->prepare("SELECT id, sender, message, created_at, read_by_store, read_by_admin FROM store_messages WHERE store_id = ? ORDER BY created_at");
     $stmt->execute([$store_id]);
     $messages = $stmt->fetchAll(PDO::FETCH_ASSOC);
     foreach ($messages as &$m) {
         $m['created_at'] = format_ts($m['created_at']);
     }
+    $pdo->prepare("UPDATE store_messages SET read_by_store=1 WHERE store_id=? AND sender='admin' AND read_by_store=0")
+        ->execute([$store_id]);
     header('Content-Type: application/json');
     echo json_encode($messages);
     exit;
 }
 
-$stmt = $pdo->prepare("SELECT sender, message, created_at FROM store_messages WHERE store_id = ? ORDER BY created_at");
+$stmt = $pdo->prepare("SELECT sender, message, created_at, read_by_store, read_by_admin FROM store_messages WHERE store_id = ? ORDER BY created_at");
 $stmt->execute([$store_id]);
 $messages = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$pdo->prepare("UPDATE store_messages SET read_by_store=1 WHERE store_id=? AND sender='admin' AND read_by_store=0")
+    ->execute([$store_id]);
+
+$adminRow = $pdo->query('SELECT first_name, last_name FROM users ORDER BY id LIMIT 1')->fetch(PDO::FETCH_ASSOC);
+$admin_name = trim(($adminRow['first_name'] ?? '') . ' ' . ($adminRow['last_name'] ?? ''));
+$your_name = trim(($_SESSION['store_first_name'] ?? '') . ' ' . ($_SESSION['store_last_name'] ?? ''));
 
 include __DIR__.'/header.php';
 ?>
+<style>
+    #messages .mine { text-align:right; }
+    #messages .bubble{display:inline-block;padding:6px 12px;border-radius:12px;margin-bottom:4px;max-width:70%;}
+    #messages .mine .bubble{background:#d1e7dd;}
+    #messages .theirs .bubble{background:#e2e3e5;}
+</style>
 <h2>Chat</h2>
 <div id="messages" class="mb-4 border rounded p-3" style="max-height:400px;overflow-y:auto;">
     <?php foreach ($messages as $msg): ?>
-        <div class="mb-2">
-            <strong><?php echo $msg['sender'] === 'admin' ? 'Admin' : 'You'; ?>:</strong>
-            <span><?php echo nl2br(htmlspecialchars($msg['message'])); ?></span>
-            <small class="text-muted ms-2"><?php echo format_ts($msg['created_at']); ?></small>
+        <div class="mb-2 <?php echo $msg['sender'] === 'admin' ? 'theirs' : 'mine'; ?>">
+            <div class="bubble">
+                <strong><?php echo $msg['sender'] === 'admin' ? htmlspecialchars($admin_name) : htmlspecialchars($your_name); ?>:</strong>
+                <span><?php echo nl2br(htmlspecialchars($msg['message'])); ?></span>
+                <small class="text-muted ms-2">
+                    <?php echo format_ts($msg['created_at']); ?>
+                    <?php if($msg['sender']==='admin' && $msg['read_by_store']): ?>
+                        <i class="bi bi-check2-all text-primary"></i>
+                    <?php elseif($msg['sender']==='store' && $msg['read_by_admin']): ?>
+                        <i class="bi bi-check2-all text-primary"></i>
+                    <?php endif; ?>
+                </small>
+            </div>
         </div>
     <?php endforeach; ?>
 </div>
-<form method="post" action="send_message.php" id="msgForm" class="input-group">
+<form method="post" action="send_message.php" id="msgForm" class="input-group align-items-end">
     <textarea name="message" class="form-control" rows="2" placeholder="Type message" required></textarea>
+    <button type="button" id="emojiBtn" class="btn btn-light border"><i class="bi bi-emoji-smile"></i></button>
     <button type="submit" class="btn btn-primary">Send</button>
     <input type="hidden" name="ajax" value="1">
+    <input type="hidden" name="parent_id" id="parent_id" value="">
 </form>
+<script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1"></script>
+<emoji-picker style="display:none; position:absolute; bottom:60px; right:20px;" id="emojiPicker"></emoji-picker>
 <script>
+const ADMIN_NAME = <?php echo json_encode($admin_name); ?>;
+const YOUR_NAME = <?php echo json_encode($your_name); ?>;
 function refreshMessages() {
     fetch('messages.php?load=1')
         .then(r => r.json())
@@ -52,12 +81,18 @@ function refreshMessages() {
             const container = document.getElementById('messages');
             container.innerHTML = '';
             data.forEach(m => {
-                const div = document.createElement('div');
-                div.className = 'mb-2';
-                div.innerHTML = `<strong>${m.sender === 'admin' ? 'Admin' : 'You'}:</strong> ` +
-                    m.message.replace(/\n/g,'<br>') +
-                    ` <small class="text-muted ms-2">${m.created_at}</small>`;
-                container.appendChild(div);
+                const wrap=document.createElement('div');
+                wrap.className='mb-2 '+(m.sender==='admin'?'theirs':'mine');
+                const div=document.createElement('div');
+                div.className='bubble';
+                let readIcon='';
+                if(m.sender==='admin' && m.read_by_store==1) readIcon=' <i class="bi bi-check2-all text-primary"></i>';
+                if(m.sender==='store' && m.read_by_admin==1) readIcon=' <i class="bi bi-check2-all text-primary"></i>';
+                div.innerHTML=`<strong>${m.sender==='admin'?ADMIN_NAME:YOUR_NAME}:</strong> `+
+                    m.message.replace(/\n/g,'<br>')+
+                    ` <small class="text-muted ms-2">${m.created_at}${readIcon}</small>`;
+                wrap.appendChild(div);
+                container.appendChild(wrap);
             });
             container.scrollTop = container.scrollHeight;
         });
@@ -68,6 +103,22 @@ document.getElementById('msgForm').addEventListener('submit', function(e){
     fetch('send_message.php', {method:'POST', body:new FormData(this)})
         .then(r=>r.json())
         .then(()=>{ this.reset(); refreshMessages(); });
+});
+document.querySelector('#msgForm textarea').addEventListener('keydown', function(e){
+    if(e.key === 'Enter' && !e.shiftKey){
+        e.preventDefault();
+        document.getElementById('msgForm').dispatchEvent(new Event('submit'));
+    }
+});
+const picker=document.getElementById('emojiPicker');
+document.getElementById('emojiBtn').addEventListener('click', ()=>{
+    picker.style.display = picker.style.display==='none' ? 'block' : 'none';
+});
+picker.addEventListener('emoji-click', e=>{
+    const ta=document.querySelector('#msgForm textarea');
+    ta.value += e.detail.unicode;
+    picker.style.display='none';
+    ta.focus();
 });
 refreshMessages();
 </script>

--- a/public/notifications.php
+++ b/public/notifications.php
@@ -1,0 +1,10 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+session_start();
+if(!isset($_SESSION['store_id'])){http_response_code(403);exit;}
+$pdo=get_pdo();
+$count=$pdo->prepare("SELECT COUNT(*) FROM store_messages WHERE store_id=? AND sender='admin' AND read_by_store=0");
+$count->execute([$_SESSION['store_id']]);
+$cnt=$count->fetchColumn();
+header('Content-Type: application/json');
+echo json_encode(['count'=>(int)$cnt]);

--- a/public/send_message.php
+++ b/public/send_message.php
@@ -19,8 +19,9 @@ if ($message === '') {
 }
 
 $pdo = get_pdo();
-$stmt = $pdo->prepare("INSERT INTO store_messages (store_id, sender, message, created_at) VALUES (?, 'store', ?, NOW())");
-$stmt->execute([$_SESSION['store_id'], $message]);
+$parent = intval($_POST['parent_id'] ?? 0) ?: null;
+$stmt = $pdo->prepare("INSERT INTO store_messages (store_id, sender, message, parent_id, created_at, read_by_store, read_by_admin) VALUES (?, 'store', ?, ?, NOW(), 1, 0)");
+$stmt->execute([$_SESSION['store_id'], $message, $parent]);
 
 if (!empty($_POST['ajax'])) {
     echo json_encode(['success' => true]);

--- a/update_database.php
+++ b/update_database.php
@@ -77,6 +77,25 @@ try {
 } catch (PDOException $e) {
     echo "• sender column might already exist\n";
 }
+// Additional messaging columns
+try {
+    $pdo->exec("ALTER TABLE store_messages ADD COLUMN parent_id INT DEFAULT NULL AFTER sender");
+    echo "✓ Added parent_id column to store_messages table\n";
+} catch (PDOException $e) {
+    echo "• parent_id column might already exist\n";
+}
+try {
+    $pdo->exec("ALTER TABLE store_messages ADD COLUMN read_by_admin TINYINT(1) DEFAULT 0 AFTER created_at");
+    echo "✓ Added read_by_admin column to store_messages table\n";
+} catch (PDOException $e) {
+    echo "• read_by_admin column might already exist\n";
+}
+try {
+    $pdo->exec("ALTER TABLE store_messages ADD COLUMN read_by_store TINYINT(1) DEFAULT 0 AFTER read_by_admin");
+    echo "✓ Added read_by_store column to store_messages table\n";
+} catch (PDOException $e) {
+    echo "• read_by_store column might already exist\n";
+}
 
 // Add hootsuite_token column to stores table
 try {


### PR DESCRIPTION
## Summary
- store first and last names in session and show them in chat
- new emoji picker, bubble styling and send on Enter
- show notification bell with unread count
- add read receipt icons and reply tracking
- update DB update script for new columns

## Testing
- `php -l admin/chat.php`
- `php -l admin/conversation.php`
- `php -l admin/notifications.php`
- `php -l public/messages.php`
- `php -l public/send_message.php`
- `php -l public/notifications.php`
- `php -l public/index.php`
- `php -l admin/header.php`
- `php -l public/header.php`
- `php -l admin/footer.php`
- `php -l public/footer.php`
- `php -l update_database.php`
- `php -l lib/auth.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6874636d59f08326b816dd6eeaee708e