### PR TITLE
Update chat interface

### DIFF
--- a/admin/footer.php
+++ b/admin/footer.php
@@ -3,7 +3,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
 <script>
 function checkNotifications(){
-    fetch('notifications.php')
+    fetch('/admin/notifications.php')
         .then(r=>r.json())
         .then(d=>{
             const countEl=document.getElementById('notifyCount');

--- a/admin/header.php
+++ b/admin/header.php
@@ -55,7 +55,7 @@ if (!isset($active)) { $active = ''; }
             <div class="ms-auto text-end small text-white">
                 <span class="position-relative me-2">
                     <i class="bi bi-bell" id="notifyBell"></i>
-                    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount" style="display:none;">0</span>
+                    <span class="position-absolute start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount" style="display:none; top:-10px;">0</span>
                 </span><br>
                 Logged in as: <?php echo htmlspecialchars(trim(($_SESSION['first_name'] ?? '') . ' ' . ($_SESSION['last_name'] ?? ''))); ?><br>
                 <a href="logout.php" class="text-white text-decoration-none">Logout</a>

--- a/admin/messages.php
+++ b/admin/messages.php
@@ -12,7 +12,7 @@ $errors = [];
 
 // Handle message submission
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['message'])) {
-    $message = trim($_POST['message'] ?? '');
+    $message = sanitize_message($_POST['message'] ?? '');
     $store_id = $_POST['store_id'] ?? null;
 
     if (empty($message)) {

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -5,3 +5,13 @@ function format_ts($time): string {
     }
     return date('n-j-y g:ia', strtotime($time));
 }
+
+/**
+ * Sanitize a chat message allowing basic formatting tags.
+ */
+function sanitize_message(string $msg): string {
+    $msg = trim($msg);
+    // Allow simple formatting tags
+    $allowed = '<b><i><u><strong><em>';    
+    return strip_tags($msg, $allowed);
+}

--- a/public/send_message.php
+++ b/public/send_message.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/helpers.php';
 session_start();
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
@@ -12,7 +13,7 @@ if (!isset($_SESSION['store_id'])) {
     exit('Not logged in');
 }
 
-$message = trim($_POST['message'] ?? '');
+$message = sanitize_message($_POST['message'] ?? '');
 if ($message === '') {
     http_response_code(400);
     exit('Message cannot be empty');


### PR DESCRIPTION
## Summary
- allow basic HTML formatting in chat messages
- fetch admin notifications from absolute path
- tweak admin notification badge position
- enlarge public chat area and add reaction icons
- add like/love reaction feature using local storage
- show store user's name in admin chat and conversation

## Testing
- `php -l lib/helpers.php`
- `php -l admin/chat.php`
- `php -l admin/conversation.php`
- `php -l admin/footer.php`
- `php -l admin/header.php`
- `php -l admin/messages.php`
- `php -l public/messages.php`
- `php -l public/send_message.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68746ee1315c832694fc44eaba112ea3