### PR TITLE
Improve filename display in admin content review

### DIFF
--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -277,7 +277,7 @@ include __DIR__.'/header.php';
                     <td>
                         <img src="thumbnail.php?id=<?php echo $r['id']; ?>&size=small" class="img-thumbnail" style="width:50px;height:50px;object-fit:cover;" alt="<?php echo htmlspecialchars($r['filename']); ?>" loading="lazy">
                     </td>
-                    <td><?php echo htmlspecialchars($r['filename']); ?></td>
+                    <td><?php echo htmlspecialchars(shorten_filename($r['filename'])); ?></td>
                     <td><?php echo htmlspecialchars($r['store_name']); ?></td>
                     <td><?php echo format_ts($r['created_at']); ?></td>
                     <td>
@@ -329,7 +329,7 @@ include __DIR__.'/header.php';
 
                     <div class="card-body">
                         <h6 class="card-title text-truncate" title="<?php echo htmlspecialchars($r['filename']); ?>">
-                            <?php echo htmlspecialchars($r['filename']); ?>
+                            <?php echo htmlspecialchars(shorten_filename($r['filename'])); ?>
                         </h6>
 
                         <p class="card-text">

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -12,6 +12,27 @@ function format_ts($time): string {
 function sanitize_message(string $msg): string {
     $msg = trim($msg);
     // Allow simple formatting tags
-    $allowed = '<b><i><u><strong><em>';    
+    $allowed = '<b><i><u><strong><em>';
     return strip_tags($msg, $allowed);
+}
+
+/**
+ * Shorten a filename to prevent overly long text in tables.
+ * Shows the first part of the basename followed by the extension.
+ */
+function shorten_filename(string $filename, int $baseLength = 8): string {
+    $dotPos = strrpos($filename, '.');
+    if ($dotPos === false) {
+        $base = $filename;
+        $ext = '';
+    } else {
+        $base = substr($filename, 0, $dotPos);
+        $ext = substr($filename, $dotPos);
+    }
+
+    if (strlen($base) <= $baseLength) {
+        return $filename;
+    }
+
+    return substr($base, 0, $baseLength) . '...' . $ext;
 }


### PR DESCRIPTION
## Summary
- add helper to shorten filenames for display
- use shortened filenames on content review page

## Testing
- `php -l lib/helpers.php`
- `php -l admin/uploads.php`


------
https://chatgpt.com/codex/tasks/task_e_687472eaef488326998c471fac14d9a8