### PR TITLE
UI tweaks for broadcast and chat

### DIFF
--- a/admin/chat.php
+++ b/admin/chat.php
@@ -104,8 +104,16 @@ include __DIR__.'/header.php';
                     <?php endif; ?>
                 </small>
                 <span class="ms-1 reactions">
-                    <i class="bi bi-hand-thumbs-up<?php if($msg['like_by_admin']||$msg['like_by_store']) echo ' text-danger'; ?>" data-id="<?php echo $msg['id']; ?>" data-type="like"></i>
-                    <i class="bi bi-heart<?php if($msg['love_by_admin']||$msg['love_by_store']) echo ' text-danger'; ?>" data-id="<?php echo $msg['id']; ?>" data-type="love"></i>
+                    <?php if($msg['like_by_admin']||$msg['like_by_store']): ?>
+                        <i class="bi bi-hand-thumbs-up-fill text-danger" data-id="<?php echo $msg['id']; ?>" data-type="like"></i>
+                    <?php else: ?>
+                        <i class="bi bi-hand-thumbs-up" data-id="<?php echo $msg['id']; ?>" data-type="like"></i>
+                    <?php endif; ?>
+                    <?php if($msg['love_by_admin']||$msg['love_by_store']): ?>
+                        <i class="bi bi-heart-fill text-danger" data-id="<?php echo $msg['id']; ?>" data-type="love"></i>
+                    <?php else: ?>
+                        <i class="bi bi-heart" data-id="<?php echo $msg['id']; ?>" data-type="love"></i>
+                    <?php endif; ?>
                 </span>
             </div>
         </div>
@@ -143,8 +151,13 @@ function refreshMessages(){
                 div.innerHTML='<strong>'+sender+':</strong> '+m.message.replace(/\n/g,'<br>')+
                     ' <small class="text-muted ms-2">'+m.created_at+readIcon+'</small>'+
                     ' <span class="ms-1 reactions">'+
-                    '<i class="bi bi-hand-thumbs-up'+((m.like_by_admin||m.like_by_store)?' text-danger':'')+'" data-id="'+m.id+'" data-type="like"></i> '+
-                    '<i class="bi bi-heart'+((m.love_by_admin||m.love_by_store)?' text-danger':'')+'" data-id="'+m.id+'" data-type="love"></i></span>';
+                    (m.like_by_admin||m.like_by_store?
+                        '<i class="bi bi-hand-thumbs-up-fill text-danger" data-id="'+m.id+'" data-type="like"></i>' :
+                        '<i class="bi bi-hand-thumbs-up" data-id="'+m.id+'" data-type="like"></i>')+' '+
+                    (m.love_by_admin||m.love_by_store?
+                        '<i class="bi bi-heart-fill text-danger" data-id="'+m.id+'" data-type="love"></i>' :
+                        '<i class="bi bi-heart" data-id="'+m.id+'" data-type="love"></i>')+
+                    '</span>';
                 wrap.appendChild(div);
                 container.appendChild(wrap);
             });

--- a/public/header.php
+++ b/public/header.php
@@ -34,8 +34,8 @@ if (!isset($_SESSION)) { session_start(); }
             <ul class="navbar-nav ms-auto">
                 <?php if(isset($_SESSION['store_id'])): ?>
                     <li class="nav-item">
-                        <a class="nav-link disabled" href="#">
-                            <i class="bi bi-shop"></i> <?php echo htmlspecialchars($_SESSION['store_name'] ?? 'Store'); ?>
+                        <a class="nav-link" href="index.php">
+                            <i class="bi bi-speedometer2"></i> Dashboard
                         </a>
                     </li>
                     <li class="nav-item">
@@ -53,15 +53,20 @@ if (!isset($_SESSION)) { session_start(); }
                             <i class="bi bi-graph-up"></i> Marketing Report
                         </a>
                     </li>
-                    <li class="nav-item position-relative">
+                    <li class="nav-item">
                         <a class="nav-link" href="messages.php">
                             <i class="bi bi-chat-dots"></i> Chat
+                        </a>
+                    </li>
+                    <li class="nav-item position-relative ms-lg-3">
+                        <a class="nav-link" href="messages.php">
+                            <i class="bi bi-bell"></i>
                             <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount" style="display:none;">0</span>
                         </a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="?logout=1">
-                            <i class="bi bi-box-arrow-right"></i> Logout
+                            <i class="bi bi-box-arrow-right"></i>
                         </a>
                     </li>
                 <?php endif; ?>

--- a/public/messages.php
+++ b/public/messages.php
@@ -59,8 +59,16 @@ include __DIR__.'/header.php';
                     <?php endif; ?>
                 </small>
                 <span class="ms-1 reactions">
-                    <i class="bi bi-hand-thumbs-up<?php if($msg['like_by_admin']||$msg['like_by_store']) echo ' text-danger'; ?>" data-id="<?php echo $msg['id']; ?>" data-type="like"></i>
-                    <i class="bi bi-heart<?php if($msg['love_by_admin']||$msg['love_by_store']) echo ' text-danger'; ?>" data-id="<?php echo $msg['id']; ?>" data-type="love"></i>
+                    <?php if($msg['like_by_admin']||$msg['like_by_store']): ?>
+                        <i class="bi bi-hand-thumbs-up-fill text-danger" data-id="<?php echo $msg['id']; ?>" data-type="like"></i>
+                    <?php else: ?>
+                        <i class="bi bi-hand-thumbs-up" data-id="<?php echo $msg['id']; ?>" data-type="like"></i>
+                    <?php endif; ?>
+                    <?php if($msg['love_by_admin']||$msg['love_by_store']): ?>
+                        <i class="bi bi-heart-fill text-danger" data-id="<?php echo $msg['id']; ?>" data-type="love"></i>
+                    <?php else: ?>
+                        <i class="bi bi-heart" data-id="<?php echo $msg['id']; ?>" data-type="love"></i>
+                    <?php endif; ?>
                 </span>
             </div>
         </div>
@@ -95,7 +103,14 @@ function refreshMessages() {
                 div.innerHTML=`<strong>${m.sender==='admin'?ADMIN_NAME:YOUR_NAME}:</strong> `+
                     m.message.replace(/\n/g,'<br>')+
                     ` <small class="text-muted ms-2">${m.created_at}${readIcon}</small>`+
-                    ` <span class="ms-1 reactions"><i class="bi bi-hand-thumbs-up${(m.like_by_admin||m.like_by_store)?' text-danger':''}" data-id="${m.id}" data-type="like"></i> <i class="bi bi-heart${(m.love_by_admin||m.love_by_store)?' text-danger':''}" data-id="${m.id}" data-type="love"></i></span>`;
+                    ' <span class="ms-1 reactions">'+
+                    (m.like_by_admin||m.like_by_store?
+                        `<i class="bi bi-hand-thumbs-up-fill text-danger" data-id="${m.id}" data-type="like"></i>`:
+                        `<i class="bi bi-hand-thumbs-up" data-id="${m.id}" data-type="like"></i>`)+' '+
+                    (m.love_by_admin||m.love_by_store?
+                        `<i class="bi bi-heart-fill text-danger" data-id="${m.id}" data-type="love"></i>`:
+                        `<i class="bi bi-heart" data-id="${m.id}" data-type="love"></i>`)+
+                    '</span>';
                 wrap.appendChild(div);
                 container.appendChild(wrap);
             });


### PR DESCRIPTION
## Summary
- show filled icons when messages are liked or loved
- tweak public navigation items and add bell notification
- display latest broadcast and chat alerts that stay dismissed until new
- add Latest Chats widget with quick reply

## Testing
- `php -l admin/chat.php`
- `php -l public/messages.php`
- `php -l public/header.php`
- `php -l public/index.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687479ddac54832696c7063f259adfcc