### PR TITLE
Extract inline styles to CSS files

### DIFF
--- a/admin/articles.php
+++ b/admin/articles.php
@@ -141,19 +141,6 @@ $active = 'articles';
 include __DIR__.'/header.php';
 ?>
 
-    <style>
-        .article-excerpt {
-            max-width: 500px;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-        .status-badge {
-            font-size: 0.875rem;
-            font-weight: 500;
-        }
-    </style>
-
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h4>Article Management</h4>
         <div class="d-flex gap-2">

--- a/admin/chat.php
+++ b/admin/chat.php
@@ -83,13 +83,7 @@ include __DIR__.'/header.php';
         <?php endforeach; ?>
     </select>
 </form>
-<style>
-    #messages .mine{ text-align:right; }
-    #messages .bubble{display:inline-block;padding:6px 12px;border-radius:12px;margin-bottom:4px;max-width:70%;}
-    #messages .mine .bubble{background:#d1e7dd;}
-    #messages .theirs .bubble{background:#e2e3e5;}
-</style>
-<div id="messages" class="mb-4" style="max-height:400px; overflow-y:auto;">
+<div id="messages" class="mb-4">
     <?php foreach ($messages as $msg): ?>
         <div class="mb-2 <?php echo $msg['sender']==='admin'?'mine':'theirs'; ?>">
             <div class="bubble">
@@ -128,7 +122,7 @@ include __DIR__.'/header.php';
     <input type="hidden" name="parent_id" id="parent_id" value="">
 </form>
 <script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1"></script>
-<emoji-picker style="display:none; position:absolute; bottom:60px; right:20px;" id="emojiPicker"></emoji-picker>
+<emoji-picker id="emojiPicker"></emoji-picker>
 <?php endif; ?>
 <script>
 const ADMIN_NAME = <?php echo json_encode($admin_name); ?>;

--- a/admin/conversation.php
+++ b/admin/conversation.php
@@ -58,12 +58,6 @@ $active = 'messages';
 include __DIR__.'/header.php';
 ?>
 <h4>Conversation with <?php echo htmlspecialchars($store['name']); ?></h4>
-<style>
-    #messages .mine{ text-align:right; }
-    #messages .bubble{display:inline-block;padding:6px 12px;border-radius:12px;margin-bottom:4px;max-width:70%;}
-    #messages .mine .bubble{background:#d1e7dd;}
-    #messages .theirs .bubble{background:#e2e3e5;}
-</style>
 <div id="messages" class="mb-4">
     <?php foreach ($messages as $msg): ?>
         <div class="mb-2 <?php echo $msg['sender']==='admin'?'mine':'theirs'; ?>">
@@ -89,7 +83,7 @@ include __DIR__.'/header.php';
     <input type="hidden" name="parent_id" id="parent_id" value="">
 </form>
 <script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1"></script>
-<emoji-picker style="display:none; position:absolute; bottom:60px; right:20px;" id="emojiPicker"></emoji-picker>
+<emoji-picker id="emojiPicker"></emoji-picker>
 <script>
 const ADMIN_NAME = <?php echo json_encode($admin_name); ?>;
 const STORE_CONTACT = <?php echo json_encode($store_contact); ?>;

--- a/admin/header.php
+++ b/admin/header.php
@@ -11,27 +11,7 @@ if (!isset($active)) { $active = ''; }
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
-    <style>
-        .navbar-brand { font-weight: 600; }
-        .navbar { background-color: #2c3e50 !important; }
-        body { background-color: #f8f9fa; }
-        .card { border: none; }
-        .btn-primary { background-color: #2c3e50; border-color: #2c3e50; }
-        .btn-primary:hover { background-color: #1a252f; border-color: #1a252f; }
-        .btn-outline-primary { color: #2c3e50; border-color: #2c3e50; }
-        .btn-outline-primary:hover { background-color: #2c3e50; border-color: #2c3e50; }
-        a { color: #2c3e50; }
-        a:hover { color: #1a252f; }
-        .page-link { color: #2c3e50; }
-        .page-item.active .page-link { background-color: #2c3e50; border-color: #2c3e50; }
-        .bg-primary { background-color: #2c3e50 !important; }
-        .bg-warning { background-color: #d39e00 !important; color: #fff !important; }
-        .bg-info { background-color: #17a2b8 !important; color: #fff !important; }
-        .text-primary { color: #2c3e50 !important; }
-        .clickable-card { cursor: pointer; transition: transform 0.2s; }
-        .clickable-card:hover { transform: translateY(-2px); box-shadow: 0 4px 8px rgba(0,0,0,0.1); }
-        .navbar-logo { height: 35px; width: auto; }
-    </style>
+    <link rel="stylesheet" href="inc/css/style.css">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark mb-4">
@@ -55,7 +35,7 @@ if (!isset($active)) { $active = ''; }
             <div class="ms-auto text-end small text-white">
                 <span class="position-relative me-2">
                     <i class="bi bi-bell" id="notifyBell"></i>
-                    <span class="position-absolute start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount" style="display:none; top:-10px;">0</span>
+                    <span class="position-absolute start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount">0</span>
                 </span><br>
                 Logged in as: <?php echo htmlspecialchars(trim(($_SESSION['first_name'] ?? '') . ' ' . ($_SESSION['last_name'] ?? ''))); ?><br>
                 <a href="logout.php" class="text-white text-decoration-none">Logout</a>

--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -1,0 +1,41 @@
+/* Admin styles */
+.navbar-brand { font-weight: 600; }
+.navbar { background-color: #2c3e50 !important; }
+body { background-color: #f8f9fa; }
+.card { border: none; }
+.btn-primary { background-color: #2c3e50; border-color: #2c3e50; }
+.btn-primary:hover { background-color: #1a252f; border-color: #1a252f; }
+.btn-outline-primary { color: #2c3e50; border-color: #2c3e50; }
+.btn-outline-primary:hover { background-color: #2c3e50; border-color: #2c3e50; }
+a { color: #2c3e50; }
+a:hover { color: #1a252f; }
+.page-link { color: #2c3e50; }
+.page-item.active .page-link { background-color: #2c3e50; border-color: #2c3e50; }
+.bg-primary { background-color: #2c3e50 !important; }
+.bg-warning { background-color: #d39e00 !important; color: #fff !important; }
+.bg-info { background-color: #17a2b8 !important; color: #fff !important; }
+.text-primary { color: #2c3e50 !important; }
+.clickable-card { cursor: pointer; transition: transform 0.2s; }
+.clickable-card:hover { transform: translateY(-2px); box-shadow: 0 4px 8px rgba(0,0,0,0.1); }
+.navbar-logo { height: 35px; width: auto; }
+#notifyCount { display: none; top:-10px; }
+#messages { max-height: 400px; overflow-y: auto; }
+#messages .mine { text-align: right; }
+#messages .bubble { display:inline-block; padding:6px 12px; border-radius:12px; margin-bottom:4px; max-width:70%; }
+#messages .mine .bubble { background:#d1e7dd; }
+#messages .theirs .bubble { background:#e2e3e5; }
+#emojiPicker { display:none; position:absolute; bottom:60px; right:20px; }
+.preview-col-sm { width: 60px; }
+.preview-img-sm { width: 50px; height: 50px; object-fit: cover; }
+.upload-card { height: 100%; transition: all 0.3s ease; border: 1px solid #c3c3c3; padding: 0.25rem; }
+.upload-card:hover { transform: translateY(-2px); box-shadow: 0 4px 8px rgba(0,0,0,0.1); }
+.new-badge { position: absolute; top: 10px; right: 10px; z-index: 10; }
+.card-img-top { height: 200px; object-fit: cover; background-color: #f8f9fa; }
+.video-thumbnail { background-color: #000; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 3rem; }
+.article-excerpt { max-width: 500px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.status-badge { font-size: 0.875rem; font-weight: 500; }
+.login-page { background-color: #262829; display: flex; align-items: center; min-height: 100vh; }
+.login-page .login-logo { max-width: 200px; margin-bottom: 30px; }
+.login-page .btn-login { background-color: #ff675b; border-color: #ff675b; color: white; }
+.login-page .btn-login:hover { background-color: #e55750; border-color: #e55750; color: white; }
+

--- a/admin/index.php
+++ b/admin/index.php
@@ -260,7 +260,7 @@ include __DIR__.'/header.php';
                             <table class="table table-sm">
                                 <thead>
                                 <tr>
-                                    <th style="width: 60px;">Preview</th>
+                                    <th class="preview-col-sm">Preview</th>
                                     <th>Time</th>
                                     <th>Store</th>
                                     <th>File</th>
@@ -274,8 +274,7 @@ include __DIR__.'/header.php';
                                     <tr>
                                         <td>
                                             <img src="thumbnail.php?id=<?php echo $upload['id']; ?>&size=small"
-                                                 class="img-thumbnail"
-                                                 style="width: 50px; height: 50px; object-fit: cover;"
+                                                 class="img-thumbnail preview-img-sm"
                                                  alt="<?php echo htmlspecialchars($upload['filename']); ?>"
                                                  loading="lazy">
                                         </td>

--- a/admin/login_header.php
+++ b/admin/login_header.php
@@ -6,28 +6,7 @@
     <title>Admin Login - MediaHub</title>
     <!-- Bootstrap CSS from CDN -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-    <style>
-        body {
-            background-color: #262829;
-            display: flex;
-            align-items: center;
-            min-height: 100vh;
-        }
-        .login-logo {
-            max-width: 200px;
-            margin-bottom: 30px;
-        }
-        .btn-login {
-            background-color: #ff675b;
-            border-color: #ff675b;
-            color: white;
-        }
-        .btn-login:hover {
-            background-color: #e55750;
-            border-color: #e55750;
-            color: white;
-        }
-    </style>
+    <link rel="stylesheet" href="inc/css/style.css">
 </head>
-<body>
+<body class="login-page">
 <div class="container">

--- a/admin/session_test.php
+++ b/admin/session_test.php
@@ -32,10 +32,10 @@ if (isset($_GET['action'])) {
     if ($_GET['action'] === 'set') {
         $_SESSION['test'] = 'Session is working!';
         $_SESSION['time'] = date('Y-m-d H:i:s');
-        echo "<p style='color:green;'>Session test data set!</p>";
+        echo "<p class='text-success'>Session test data set!</p>";
     } elseif ($_GET['action'] === 'clear') {
         session_destroy();
-        echo "<p style='color:red;'>Session destroyed!</p>";
+        echo "<p class='text-danger'>Session destroyed!</p>";
     }
 }
 ?>

--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -167,38 +167,6 @@ $active = 'uploads';
 include __DIR__.'/header.php';
 ?>
 
-    <style>
-        .upload-card {
-            height: 100%;
-            transition: all 0.3s ease;
-            border: 1px solid #c3c3c3;
-            padding: 0.25rem;
-        }
-        .upload-card:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-        }
-        .new-badge {
-            position: absolute;
-            top: 10px;
-            right: 10px;
-            z-index: 10;
-        }
-        .card-img-top {
-            height: 200px;
-            object-fit: cover;
-            background-color: #f8f9fa;
-        }
-        .video-thumbnail {
-            background-color: #000;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: #fff;
-            font-size: 3rem;
-        }
-    </style>
-
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h4>Content Review</h4>
         <div class="d-flex align-items-center gap-3">
@@ -263,7 +231,7 @@ include __DIR__.'/header.php';
             <table class="table table-sm align-middle">
                 <thead>
                 <tr>
-                    <th style="width: 60px;">Preview</th>
+                    <th class="preview-col-sm">Preview</th>
                     <th>File</th>
                     <th>Store</th>
                     <th>Date</th>
@@ -275,7 +243,7 @@ include __DIR__.'/header.php';
                 <?php foreach ($rows as $r): ?>
                 <tr>
                     <td>
-                        <img src="thumbnail.php?id=<?php echo $r['id']; ?>&size=small" class="img-thumbnail" style="width:50px;height:50px;object-fit:cover;" alt="<?php echo htmlspecialchars($r['filename']); ?>" loading="lazy">
+                        <img src="thumbnail.php?id=<?php echo $r['id']; ?>&size=small" class="img-thumbnail preview-img-sm" alt="<?php echo htmlspecialchars($r['filename']); ?>" loading="lazy">
                     </td>
                     <td><?php echo htmlspecialchars(shorten_filename($r['filename'])); ?></td>
                     <td><?php echo htmlspecialchars($r['store_name']); ?></td>

--- a/public/articles.php
+++ b/public/articles.php
@@ -136,23 +136,6 @@ $tab = $_GET['tab'] ?? 'submit';
 include __DIR__.'/header.php';
 ?>
 
-    <style>
-        .ck-editor__editable {
-            min-height: 400px;
-        }
-        .article-status {
-            font-size: 0.875rem;
-            font-weight: 500;
-        }
-        .article-card {
-            transition: all 0.3s ease;
-        }
-        .article-card:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-        }
-    </style>
-
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2>Content Articles - <?php echo htmlspecialchars($store_name); ?></h2>
         <a href="index.php" class="btn btn-secondary">Back to Uploads</a>

--- a/public/header.php
+++ b/public/header.php
@@ -11,19 +11,7 @@ if (!isset($_SESSION)) { session_start(); }
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
-    <style>
-        .navbar-brand { font-weight: 600; }
-        .navbar { background-color: #2c3e50 !important; }
-        body { background-color: #f8f9fa; }
-        .card { border: none; }
-        .btn-primary { background-color: #2c3e50; border-color: #2c3e50; }
-        .btn-primary:hover { background-color: #1a252f; border-color: #1a252f; }
-        .btn-outline-primary { color: #2c3e50; border-color: #2c3e50; }
-        .btn-outline-primary:hover { background-color: #2c3e50; border-color: #2c3e50; }
-        .page-link { color: #2c3e50; }
-        .page-item.active .page-link { background-color: #2c3e50; border-color: #2c3e50; }
-        .navbar-logo { height: 30px; width: auto; }
-    </style>
+    <link rel="stylesheet" href="inc/css/style.css">
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark">
@@ -65,7 +53,7 @@ if (!isset($_SESSION)) { session_start(); }
                     <li class="nav-item position-relative ms-lg-3">
                         <a class="nav-link" href="messages.php">
                             <i class="bi bi-bell"></i>
-                            <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount" style="display:none;">0</span>
+                            <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount">0</span>
                         </a>
                     </li>
                     <li class="nav-item">

--- a/public/history.php
+++ b/public/history.php
@@ -89,7 +89,7 @@ include __DIR__.'/header.php';
         <table class="table table-hover align-middle" id="uploadsTable">
             <thead>
             <tr>
-                <th style="width: 100px;">Preview</th>
+                <th class="preview-col">Preview</th>
                 <th>Date</th>
                 <th>File Name</th>
                 <th>Description</th>
@@ -106,8 +106,7 @@ include __DIR__.'/header.php';
                 <tr>
                     <td>
                         <img src="thumbnail.php?id=<?php echo $upload['id']; ?>&size=small"
-                             class="img-thumbnail"
-                             style="width: 80px; height: 80px; object-fit: cover;"
+                             class="img-thumbnail preview-img"
                              alt="<?php echo htmlspecialchars($upload['filename']); ?>"
                              loading="lazy">
                     </td>

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -1,0 +1,38 @@
+/* Public styles */
+.navbar-brand { font-weight: 600; }
+.navbar { background-color: #2c3e50 !important; }
+body { background-color: #f8f9fa; }
+.card { border: none; }
+.btn-primary { background-color: #2c3e50; border-color: #2c3e50; }
+.btn-primary:hover { background-color: #1a252f; border-color: #1a252f; }
+.btn-outline-primary { color: #2c3e50; border-color: #2c3e50; }
+.btn-outline-primary:hover { background-color: #2c3e50; border-color: #2c3e50; }
+.page-link { color: #2c3e50; }
+.page-item.active .page-link { background-color: #2c3e50; border-color: #2c3e50; }
+.navbar-logo { height: 30px; width: auto; }
+#notifyCount { display: none; }
+#cameraInput { display: none; }
+#latestChats { max-height: 300px; overflow-y: auto; }
+#latestChats .mine { text-align: right; }
+#latestChats .bubble { display: inline-block; padding: 6px 12px; border-radius: 12px; margin-bottom: 4px; max-width: 70%; }
+#latestChats .mine .bubble { background: #d1e7dd; }
+#latestChats .theirs .bubble { background: #e2e3e5; }
+#messages { height: 70vh; overflow-y: auto; margin-left: 0.5rem; margin-right: 0.5rem; }
+#messages .mine { text-align: right; }
+#messages .bubble { display: inline-block; padding: 6px 12px; border-radius: 12px; margin-bottom: 4px; max-width: 70%; }
+#messages .mine .bubble { background: #d1e7dd; }
+#messages .theirs .bubble { background: #e2e3e5; }
+#emojiPicker { display: none; position: absolute; bottom: 60px; right: 20px; }
+#reportFrame { width: 100%; border: 0; }
+.preview-col { width: 100px; }
+.preview-img { width: 80px; height: 80px; object-fit: cover; }
+.login-page { background-color: #262829; display: flex; align-items: center; min-height: 100vh; }
+.login-page .login-logo { max-width: 200px; margin-bottom: 30px; }
+.login-page .btn-login { background-color: #ff675b; border-color: #ff675b; color: white; }
+.login-page .btn-login:hover { background-color: #e55750; border-color: #e55750; color: white; }
+.login-page .admin-link { margin-top: 20px; font-size: 0.875rem; }
+.login-page .store-pin-title { font-size: 1.5rem; }
+.ck-editor__editable { min-height: 400px; }
+.article-status { font-size: 0.875rem; font-weight: 500; }
+.article-card { transition: all 0.3s ease; }
+.article-card:hover { transform: translateY(-2px); box-shadow: 0 4px 8px rgba(0,0,0,0.1); }

--- a/public/index.php
+++ b/public/index.php
@@ -72,37 +72,9 @@ if (!$isLoggedIn) {
         <title>Store Login - MediaHub</title>
         <!-- Bootstrap CSS from CDN -->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-        <style>
-            body {
-                background-color: #262829;
-                display: flex;
-                align-items: center;
-                min-height: 100vh;
-            }
-            .login-logo {
-                max-width: 200px;
-                margin-bottom: 30px;
-            }
-            .btn-login {
-                background-color: #ff675b;
-                border-color: #ff675b;
-                color: white;
-            }
-            .btn-login:hover {
-                background-color: #e55750;
-                border-color: #e55750;
-                color: white;
-            }
-            .admin-link {
-                margin-top: 20px;
-                font-size: 0.875rem;
-            }
-            .store-pin-title {
-                font-size: 1.5rem;
-            }
-        </style>
+        <link rel="stylesheet" href="inc/css/style.css">
     </head>
-    <body>
+    <body class="login-page">
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-md-6 col-lg-4">
@@ -477,7 +449,7 @@ include __DIR__.'/header.php';
                                     <i class="bi bi-camera"></i> Camera
                                 </button>
                             </div>
-                            <input type="file" id="cameraInput" accept="image/*,video/*" capture="camera" style="display:none;">
+                            <input type="file" id="cameraInput" accept="image/*,video/*" capture="camera">
                             <div class="form-text">You can select multiple files. Maximum 20MB per file.</div>
                         </div>
 
@@ -531,13 +503,7 @@ include __DIR__.'/header.php';
             <div class="card shadow-sm">
                 <div class="card-body">
                     <h5 class="card-title">Chat Feed</h5>
-                    <style>
-                        #latestChats .mine { text-align:right; }
-                        #latestChats .bubble{display:inline-block;padding:6px 12px;border-radius:12px;margin-bottom:4px;max-width:70%;}
-                        #latestChats .mine .bubble{background:#d1e7dd;}
-                        #latestChats .theirs .bubble{background:#e2e3e5;}
-                    </style>
-                    <div id="latestChats" style="max-height:300px;overflow-y:auto;">
+                    <div id="latestChats">
                         <?php foreach ($recent_chats as $msg): ?>
                             <div class="mb-2 <?php echo $msg['sender']==='admin'?'theirs':'mine'; ?>">
                                 <div class="bubble">

--- a/public/marketing.php
+++ b/public/marketing.php
@@ -18,7 +18,7 @@ include __DIR__.'/header.php';
     <a href="index.php" class="btn btn-primary">Back to Upload</a>
 </div>
 <?php if ($url): ?>
-    <iframe id="reportFrame" src="<?php echo htmlspecialchars($url); ?>" style="width:100%; border:0;" allowfullscreen></iframe>
+    <iframe id="reportFrame" src="<?php echo htmlspecialchars($url); ?>" allowfullscreen></iframe>
     <script>
         function resizeFrame(){
             var iframe=document.getElementById('reportFrame');

--- a/public/messages.php
+++ b/public/messages.php
@@ -38,13 +38,7 @@ $your_name = trim(($_SESSION['store_first_name'] ?? '') . ' ' . ($_SESSION['stor
 
 include __DIR__.'/header.php';
 ?>
-<style>
-    #messages .mine { text-align:right; }
-    #messages .bubble{display:inline-block;padding:6px 12px;border-radius:12px;margin-bottom:4px;max-width:70%;}
-    #messages .mine .bubble{background:#d1e7dd;}
-    #messages .theirs .bubble{background:#e2e3e5;}
-</style>
-<div id="messages" class="mb-4 border rounded p-2" style="height:70vh;overflow-y:auto;margin-left:0.5rem;margin-right:0.5rem;">
+<div id="messages" class="mb-4 border rounded p-2">
     <?php foreach ($messages as $msg): ?>
         <div class="mb-2 <?php echo $msg['sender'] === 'admin' ? 'theirs' : 'mine'; ?>">
             <div class="bubble">
@@ -82,7 +76,7 @@ include __DIR__.'/header.php';
     <input type="hidden" name="parent_id" id="parent_id" value="">
 </form>
 <script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1"></script>
-<emoji-picker style="display:none; position:absolute; bottom:60px; right:20px;" id="emojiPicker"></emoji-picker>
+<emoji-picker id="emojiPicker"></emoji-picker>
 <script>
 const ADMIN_NAME = <?php echo json_encode($admin_name); ?>;
 const YOUR_NAME = <?php echo json_encode($your_name); ?>;


### PR DESCRIPTION
## Summary
- create `style.css` for public and admin
- reference new stylesheets in headers
- move page-specific styles to CSS and remove inline style tags
- replace inline style attributes with classes

## Testing
- `php -l public/index.php`
- `php -l public/messages.php`
- `php -l public/articles.php`
- `php -l public/history.php`
- `php -l public/marketing.php`
- `php -l public/header.php`
- `php -l admin/header.php`
- `php -l admin/login_header.php`
- `php -l admin/chat.php`
- `php -l admin/conversation.php`
- `php -l admin/uploads.php`
- `php -l admin/articles.php`
- `php -l admin/index.php`

------
https://chatgpt.com/codex/tasks/task_e_687483a587388326ad2a4305ec6693c3