### PR TITLE
Update navigation layout and add chat counts

### DIFF
--- a/admin/header.php
+++ b/admin/header.php
@@ -33,15 +33,15 @@ $version = trim(file_get_contents(__DIR__.'/../VERSION'));
                 <li class="nav-item"><a class="nav-link<?php if($active==='settings') echo ' active'; ?>" href="settings.php">Settings</a></li>
                 <li class="nav-item"><a class="nav-link<?php if($active==='users') echo ' active'; ?>" href="users.php">Users</a></li>
             </ul>
-            <div class="ms-auto text-end small text-white">
+            <div id="adminUserInfo" class="ms-auto text-end small text-white d-flex align-items-center">
+                <span class="me-2">Logged in as: <?php echo htmlspecialchars(trim(($_SESSION['first_name'] ?? '') . ' ' . ($_SESSION['last_name'] ?? ''))); ?></span>
                 <span class="position-relative me-2">
                     <i class="bi bi-bell" id="notifyBell"></i>
                     <span class="position-absolute start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount">0</span>
-                </span><br>
-                Logged in as: <?php echo htmlspecialchars(trim(($_SESSION['first_name'] ?? '') . ' ' . ($_SESSION['last_name'] ?? ''))); ?><br>
-                <a href="logout.php" class="text-white text-decoration-none">Logout</a>
+                </span>
+                <a href="logout.php" class="text-white text-decoration-none"><i class="bi bi-box-arrow-right"></i></a>
             </div>
         </div>
     </div>
 </nav>
-<div class="container pb-5">
+<div class="container-fluid pb-5">

--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -18,6 +18,7 @@ a:hover { color: #1a252f; }
 .clickable-card { cursor: pointer; transition: transform 0.2s; }
 .clickable-card:hover { transform: translateY(-2px); box-shadow: 0 4px 8px rgba(0,0,0,0.1); }
 .navbar-logo { height: 35px; width: auto; }
+#adminUserInfo a { color: #fff; }
 #notifyCount { display: none; top:-10px; }
 #messages { max-height: 400px; overflow-y: auto; }
 #messages .mine { text-align: right; }

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -48,10 +48,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 // Get stores sorted by name
-$stores = $pdo->query('SELECT s.*, COUNT(u.id) as upload_count 
-                       FROM stores s 
-                       LEFT JOIN uploads u ON s.id = u.store_id 
-                       GROUP BY s.id 
+$stores = $pdo->query('SELECT s.*, COUNT(u.id) as upload_count,
+                       (SELECT COUNT(*) FROM store_messages m WHERE m.store_id = s.id) as chat_count
+                       FROM stores s
+                       LEFT JOIN uploads u ON s.id = u.store_id
+                       GROUP BY s.id
                        ORDER BY s.name ASC')->fetchAll(PDO::FETCH_ASSOC);
 
 $active = 'stores';
@@ -87,7 +88,7 @@ include __DIR__.'/header.php';
                         <th>PIN</th>
                         <th>Admin Email</th>
                         <th>Drive Folder ID</th>
-                        <th>Hootsuite Token</th>
+                        <th>Total Chats</th>
                         <th>Uploads</th>
                         <th>Actions</th>
                     </tr>
@@ -108,7 +109,7 @@ include __DIR__.'/header.php';
                                 <?php endif; ?>
                             </td>
                             <td>
-                                <?php echo $s['hootsuite_token'] ? '<span class="badge bg-success">Set</span>' : '<span class="badge bg-secondary">None</span>'; ?>
+                                <span class="badge bg-info"><?php echo $s['chat_count']; ?></span>
                             </td>
                             <td>
                                 <span class="badge bg-info"><?php echo $s['upload_count']; ?></span>

--- a/public/header.php
+++ b/public/header.php
@@ -23,47 +23,24 @@ if (!isset($_SESSION)) { session_start(); }
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarPublic">
-            <ul class="navbar-nav ms-auto">
-                <?php if(isset($_SESSION['store_id'])): ?>
-                    <li class="nav-item">
-                        <a class="nav-link" href="index.php">
-                            <i class="bi bi-speedometer2"></i> Dashboard
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="history.php">
-                            <i class="bi bi-clock-history"></i> History
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="calendar.php">
-                            <i class="bi bi-calendar-event"></i> Calendar
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="marketing.php">
-                            <i class="bi bi-graph-up"></i> Marketing Report
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="messages.php">
-                            <i class="bi bi-chat-dots"></i> Chat
-                        </a>
-                    </li>
-                    <li class="nav-item position-relative ms-lg-3">
-                        <a class="nav-link" href="messages.php">
-                            <i class="bi bi-bell"></i>
-                            <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount">0</span>
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="?logout=1">
-                            <i class="bi bi-box-arrow-right"></i>
-                        </a>
-                    </li>
-                <?php endif; ?>
+            <?php if(isset($_SESSION['store_id'])): ?>
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item"><a class="nav-link" href="index.php"><i class="bi bi-speedometer2"></i> Dashboard</a></li>
+                <li class="nav-item"><a class="nav-link" href="history.php"><i class="bi bi-clock-history"></i> History</a></li>
+                <li class="nav-item"><a class="nav-link" href="calendar.php"><i class="bi bi-calendar-event"></i> Calendar</a></li>
+                <li class="nav-item"><a class="nav-link" href="marketing.php"><i class="bi bi-graph-up"></i> Marketing Report</a></li>
+                <li class="nav-item"><a class="nav-link" href="messages.php"><i class="bi bi-chat-dots"></i> Chat</a></li>
             </ul>
+            <div id="publicUserInfo" class="ms-auto d-flex align-items-center navbar-text small text-white">
+                <span class="me-2">Logged in as: <?php echo htmlspecialchars(trim(($_SESSION['store_first_name'] ?? '') . ' ' . ($_SESSION['store_last_name'] ?? ''))); ?></span>
+                <a class="nav-link position-relative text-white me-2" href="messages.php">
+                    <i class="bi bi-bell"></i>
+                    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount">0</span>
+                </a>
+                <a class="nav-link text-white" href="?logout=1"><i class="bi bi-box-arrow-right"></i></a>
+            </div>
+            <?php endif; ?>
         </div>
     </div>
 </nav>
-<div class="container mt-4">
+<div class="container-fluid mt-4">

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -10,6 +10,7 @@ body { background-color: #f8f9fa; }
 .page-link { color: #2c3e50; }
 .page-item.active .page-link { background-color: #2c3e50; border-color: #2c3e50; }
 .navbar-logo { height: 30px; width: auto; }
+#publicUserInfo a { color: #fff; }
 #notifyCount { display: none; }
 #cameraInput { display: none; }
 #latestChats { max-height: 300px; overflow-y: auto; }

--- a/public/index.php
+++ b/public/index.php
@@ -386,11 +386,7 @@ function getUploadErrorMessage($code) {
 include __DIR__.'/header.php';
 ?>
 
-    <div class="mb-4">
-        <h2 class="mb-0">Welcome</h2>
-        <div class="small"><?php echo htmlspecialchars($your_name); ?> from</div>
-        <h3 class="mt-1"><?php echo htmlspecialchars($store_name); ?></h3>
-    </div>
+
 
 <?php if (!empty($latest_broadcast)): ?>
     <div class="alert alert-danger alert-dismissible fade show" role="alert" id="broadcastAlert" data-id="<?php echo $latest_broadcast['id']; ?>">
@@ -489,7 +485,7 @@ include __DIR__.'/header.php';
                         <a href="calendar.php" class="btn btn-primary">
                             <i class="bi bi-calendar-event"></i> View Calendar
                         </a>
-                        <a href="?logout=1" class="btn btn-secondary">
+                        <a href="?logout=1" class="btn btn-primary">
                             <i class="bi bi-box-arrow-right"></i> Change Store
                         </a>
                     </div>


### PR DESCRIPTION
## Summary
- align admin navbar icons with a logout icon
- convert containers to full width
- show logged in user with icons on the public navbar
- remove welcome header from public index and style quick action buttons
- replace Hootsuite token column with chat counts in Store Management
- tweak styles for the new navbar sections

## Testing
- `php -l admin/header.php`
- `php -l public/header.php`
- `php -l public/index.php`
- `php -l admin/stores.php`

------
https://chatgpt.com/codex/tasks/task_e_68748a91ede48326b3b9b08429193253