### PR TITLE
Fix TypeError for missing Hootsuite token

### DIFF
--- a/lib/hootsuite.php
+++ b/lib/hootsuite.php
@@ -2,7 +2,7 @@
 /**
  * Minimal Hootsuite API helper. Currently only fetches scheduled messages.
  */
-function hootsuite_get_scheduled_posts(string $token): array {
+function hootsuite_get_scheduled_posts(?string $token): array {
     if (empty($token)) {
         return [];
     }


### PR DESCRIPTION
## Summary
- relax the type-hint of `hootsuite_get_scheduled_posts` so a missing token does not cause a fatal error

## Testing
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68748fc71cf8832696de798571f0daf5