### PR TITLE
Rename Dripley integration to Groundhogg

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ A simple `deploy.sh` script is provided to rsync the files to a remote host. Edi
 ## Versioning
 
 The current version is tracked in the `VERSION` file. Run `php scripts/bump_version.php` after committing changes to automatically bump the patch number and append the latest commit message to `CHANGELOG.md`. The admin interface displays this version in the bottom-right corner.
+
+### Groundhogg CRM Integration
+
+To sync new store contacts with your Groundhogg installation, open **Admin → Settings** and enter the following details under **Groundhogg CRM Integration**:
+
+1. **WordPress Site URL** – the base URL of the site where Groundhogg is installed.
+2. **Groundhogg API Username** – the WordPress user to authenticate with.
+3. **Groundhogg API App Password** – an [application password](https://wordpress.org/support/article/application-passwords/) generated for that user.
+
+After saving, use the **Test Connection** button to verify communication with your Groundhogg REST API.

--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
-require_once __DIR__.'/../lib/dripley.php';
+require_once __DIR__.'/../lib/groundhogg.php';
 require_login();
 $pdo = get_pdo();
 
@@ -61,7 +61,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $success = true;
                 $store_users[] = ['id' => $insertId, 'email' => $email, 'first_name' => $first, 'last_name' => $last];
 
-                // Send to Dripley
+                // Send to Groundhogg
                 $contact = [
                     'first_name'   => $first,
                     'last_name'    => $last,
@@ -72,7 +72,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'tags'         => ['media-hub', 'store-onboarding'],
                     'store_id'     => (int)$id
                 ];
-                send_contact_to_dripley($contact);
+                groundhogg_send_contact($contact);
             } catch (PDOException $e) {
                 $errors[] = 'User already exists for this store';
             }

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
-require_once __DIR__.'/../lib/dripley.php';
+require_once __DIR__.'/../lib/groundhogg.php';
 require_login();
 $pdo = get_pdo();
 
@@ -44,9 +44,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'store_article_notification_subject' => $_POST['store_article_notification_subject'] ?? 'Article Submission Confirmation - Cosmick Media',
         'article_approval_subject' => $_POST['article_approval_subject'] ?? 'Article Status Update - Cosmick Media',
         'max_article_length' => $_POST['max_article_length'] ?? '50000',
-        'dripley_site_url' => trim($_POST['dripley_site_url'] ?? ''),
-        'dripley_username' => trim($_POST['dripley_username'] ?? ''),
-        'dripley_app_password' => trim($_POST['dripley_app_password'] ?? '')
+        'groundhogg_site_url' => trim($_POST['groundhogg_site_url'] ?? ''),
+        'groundhogg_username' => trim($_POST['groundhogg_username'] ?? ''),
+        'groundhogg_app_password' => trim($_POST['groundhogg_app_password'] ?? '')
     ];
 
     foreach ($settings as $name => $value) {
@@ -79,8 +79,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $statuses = $pdo->query('SELECT id, name, color FROM upload_statuses ORDER BY id')->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    if (isset($_POST['test_dripley'])) {
-        [$ok, $msg] = test_dripley_connection();
+    if (isset($_POST['test_groundhogg'])) {
+        [$ok, $msg] = test_groundhogg_connection();
         $test_result = [$ok, $msg];
     }
     $success = true;
@@ -98,9 +98,9 @@ $admin_article_notification_subject = get_setting('admin_article_notification_su
 $store_article_notification_subject = get_setting('store_article_notification_subject') ?: 'Article Submission Confirmation - Cosmick Media';
 $article_approval_subject = get_setting('article_approval_subject') ?: 'Article Status Update - Cosmick Media';
 $max_article_length = get_setting('max_article_length') ?: '50000';
-$dripley_site_url = get_setting('dripley_site_url');
-$dripley_username = get_setting('dripley_username');
-$dripley_app_password = get_setting('dripley_app_password');
+$groundhogg_site_url = get_setting('groundhogg_site_url');
+$groundhogg_username = get_setting('groundhogg_username');
+$groundhogg_app_password = get_setting('groundhogg_app_password');
 
 $active = 'settings';
 include __DIR__.'/header.php';
@@ -116,11 +116,11 @@ include __DIR__.'/header.php';
 <?php endif; ?>
 <?php if ($test_result !== null): ?>
     <?php if ($test_result[0]): ?>
-        <div class="alert alert-success alert-dismissible fade show" role="alert">Dripley connection successful!
+        <div class="alert alert-success alert-dismissible fade show" role="alert">Groundhogg connection successful!
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         </div>
     <?php else: ?>
-        <div class="alert alert-danger alert-dismissible fade show" role="alert">Dripley connection failed: <?php echo htmlspecialchars($test_result[1]); ?>
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">Groundhogg connection failed: <?php echo htmlspecialchars($test_result[1]); ?>
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         </div>
     <?php endif; ?>
@@ -193,23 +193,23 @@ include __DIR__.'/header.php';
         </div>
 
         <div class="card mb-4">
-            <div class="card-header">
-                <h5 class="mb-0">Dripley CRM Integration</h5>
+        <div class="card-header">
+                <h5 class="mb-0">Groundhogg CRM Integration</h5>
             </div>
             <div class="card-body">
                 <div class="mb-3">
-                    <label for="dripley_site_url" class="form-label">WordPress Site URL</label>
-                    <input type="text" name="dripley_site_url" id="dripley_site_url" class="form-control" value="<?php echo htmlspecialchars($dripley_site_url); ?>" placeholder="https://crm.example.com">
+                    <label for="groundhogg_site_url" class="form-label">WordPress Site URL</label>
+                    <input type="text" name="groundhogg_site_url" id="groundhogg_site_url" class="form-control" value="<?php echo htmlspecialchars($groundhogg_site_url); ?>" placeholder="https://crm.example.com">
                 </div>
                 <div class="mb-3">
-                    <label for="dripley_username" class="form-label">Dripley API Username</label>
-                    <input type="text" name="dripley_username" id="dripley_username" class="form-control" value="<?php echo htmlspecialchars($dripley_username); ?>">
+                    <label for="groundhogg_username" class="form-label">Groundhogg API Username</label>
+                    <input type="text" name="groundhogg_username" id="groundhogg_username" class="form-control" value="<?php echo htmlspecialchars($groundhogg_username); ?>">
                 </div>
                 <div class="mb-3">
-                    <label for="dripley_app_password" class="form-label">Dripley API App Password</label>
-                    <input type="password" name="dripley_app_password" id="dripley_app_password" class="form-control" value="<?php echo htmlspecialchars($dripley_app_password); ?>">
+                    <label for="groundhogg_app_password" class="form-label">Groundhogg API App Password</label>
+                    <input type="password" name="groundhogg_app_password" id="groundhogg_app_password" class="form-control" value="<?php echo htmlspecialchars($groundhogg_app_password); ?>">
                 </div>
-                <button class="btn btn-secondary" type="submit" name="test_dripley">Test Connection</button>
+                <button class="btn btn-secondary" type="submit" name="test_groundhogg">Test Connection</button>
             </div>
         </div>
 

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
-require_once __DIR__.'/../lib/dripley.php';
+require_once __DIR__.'/../lib/groundhogg.php';
 require_login();
 $pdo = get_pdo();
 
@@ -32,7 +32,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $storeId = $pdo->lastInsertId();
             $success[] = 'Store added successfully';
 
-            // Send to Dripley
+            // Send to Groundhogg
             $contact = [
                 'first_name'   => $_POST['first_name'] ?? '',
                 'last_name'    => $_POST['last_name'] ?? '',
@@ -43,7 +43,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 'tags'         => ['media-hub', 'store-onboarding'],
                 'store_id'     => (int)$storeId
             ];
-            send_contact_to_dripley($contact);
+            groundhogg_send_contact($contact);
         }
     }
     if (isset($_POST['delete'])) {

--- a/lib/groundhogg.php
+++ b/lib/groundhogg.php
@@ -1,22 +1,22 @@
 <?php
 /**
- * Helper functions for Dripley CRM integration
+ * Helper functions for Groundhogg CRM integration
  */
 require_once __DIR__.'/db.php';
 
-function dripley_get_settings(): array {
+function groundhogg_get_settings(): array {
     $pdo = get_pdo();
-    $stmt = $pdo->prepare("SELECT name, value FROM settings WHERE name IN ('dripley_site_url','dripley_username','dripley_app_password')");
+    $stmt = $pdo->prepare("SELECT name, value FROM settings WHERE name IN ('groundhogg_site_url','groundhogg_username','groundhogg_app_password')");
     $stmt->execute();
     $rows = $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
     return [
-        'site_url'  => $rows['dripley_site_url'] ?? '',
-        'username'  => $rows['dripley_username'] ?? '',
-        'app_pass'  => $rows['dripley_app_password'] ?? ''
+        'site_url'  => $rows['groundhogg_site_url'] ?? '',
+        'username'  => $rows['groundhogg_username'] ?? '',
+        'app_pass'  => $rows['groundhogg_app_password'] ?? ''
     ];
 }
 
-function dripley_log(string $message, ?int $store_id = null, string $action = 'dripley'): void {
+function groundhogg_log(string $message, ?int $store_id = null, string $action = 'groundhogg'): void {
     try {
         $pdo = get_pdo();
         $stmt = $pdo->prepare('INSERT INTO logs (store_id, action, message, created_at, ip) VALUES (?, ?, ?, NOW(), ?)');
@@ -27,8 +27,8 @@ function dripley_log(string $message, ?int $store_id = null, string $action = 'd
     }
 }
 
-function send_contact_to_dripley(array $contactData): bool {
-    $settings = dripley_get_settings();
+function groundhogg_send_contact(array $contactData): bool {
+    $settings = groundhogg_get_settings();
     if (!$settings['site_url'] || !$settings['username'] || !$settings['app_pass']) {
         return false;
     }
@@ -49,13 +49,13 @@ function send_contact_to_dripley(array $contactData): bool {
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
 
-    dripley_log("POST $url HTTP $httpCode Response: $response", $contactData['store_id'] ?? null, 'dripley_contact');
+    groundhogg_log("POST $url HTTP $httpCode Response: $response", $contactData['store_id'] ?? null, 'groundhogg_contact');
 
     return $httpCode >= 200 && $httpCode < 300;
 }
 
-function test_dripley_connection(): array {
-    $settings = dripley_get_settings();
+function test_groundhogg_connection(): array {
+    $settings = groundhogg_get_settings();
     if (!$settings['site_url'] || !$settings['username'] || !$settings['app_pass']) {
         return [false, 'Missing configuration'];
     }
@@ -74,7 +74,7 @@ function test_dripley_connection(): array {
     curl_close($ch);
 
     $success = $httpCode >= 200 && $httpCode < 300;
-    dripley_log("GET $url HTTP $httpCode Response: $response", null, 'dripley_test');
+    groundhogg_log("GET $url HTTP $httpCode Response: $response", null, 'groundhogg_test');
 
     return [$success, $response ?: ''];
 }


### PR DESCRIPTION
## Summary
- rename Dripley CRM integration to Groundhogg
- migrate old `dripley_*` settings to new names
- update admin settings UI and integration helper
- document new setup steps

## Testing
- `php -l admin/settings.php`
- `php -l admin/stores.php`
- `php -l admin/edit_store.php`
- `php -l lib/groundhogg.php`
- `php -l update_database.php`


------
https://chatgpt.com/codex/tasks/task_e_68756ef3405c8326a92903ed9b360663