### PR TITLE
Add Groundhogg debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ To sync new store contacts with your Groundhogg installation, open **Admin → S
 3. **Groundhogg API App Password** – an [application password](https://wordpress.org/support/article/application-passwords/) generated for that user.
 
 After saving, use the **Test Connection** button to verify communication with your Groundhogg REST API.
+
+If you need to troubleshoot API issues, enable **Debug Logging** in the settings panel. When enabled, detailed request and response information is written to `logs/groundhogg.log` in the project root.

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -46,7 +46,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'max_article_length' => $_POST['max_article_length'] ?? '50000',
         'groundhogg_site_url' => trim($_POST['groundhogg_site_url'] ?? ''),
         'groundhogg_username' => trim($_POST['groundhogg_username'] ?? ''),
-        'groundhogg_app_password' => trim($_POST['groundhogg_app_password'] ?? '')
+        'groundhogg_app_password' => trim($_POST['groundhogg_app_password'] ?? ''),
+        'groundhogg_debug' => isset($_POST['groundhogg_debug']) ? '1' : '0'
     ];
 
     foreach ($settings as $name => $value) {
@@ -101,6 +102,7 @@ $max_article_length = get_setting('max_article_length') ?: '50000';
 $groundhogg_site_url = get_setting('groundhogg_site_url');
 $groundhogg_username = get_setting('groundhogg_username');
 $groundhogg_app_password = get_setting('groundhogg_app_password');
+$groundhogg_debug = get_setting('groundhogg_debug');
 
 $active = 'settings';
 include __DIR__.'/header.php';
@@ -208,6 +210,11 @@ include __DIR__.'/header.php';
                 <div class="mb-3">
                     <label for="groundhogg_app_password" class="form-label">Groundhogg API App Password</label>
                     <input type="password" name="groundhogg_app_password" id="groundhogg_app_password" class="form-control" value="<?php echo htmlspecialchars($groundhogg_app_password); ?>">
+                </div>
+                <div class="form-check mb-3">
+                    <input type="checkbox" name="groundhogg_debug" id="groundhogg_debug" class="form-check-input" value="1" <?php if ($groundhogg_debug === '1') echo 'checked'; ?>>
+                    <label for="groundhogg_debug" class="form-check-label">Enable Debug Logging</label>
+                    <div class="form-text">Logs API communication to <code>logs/groundhogg.log</code></div>
                 </div>
                 <button class="btn btn-secondary" type="submit" name="test_groundhogg">Test Connection</button>
             </div>

--- a/lib/groundhogg.php
+++ b/lib/groundhogg.php
@@ -6,14 +6,35 @@ require_once __DIR__.'/db.php';
 
 function groundhogg_get_settings(): array {
     $pdo = get_pdo();
-    $stmt = $pdo->prepare("SELECT name, value FROM settings WHERE name IN ('groundhogg_site_url','groundhogg_username','groundhogg_app_password')");
+    $stmt = $pdo->prepare(
+        "SELECT name, value FROM settings WHERE name IN ('groundhogg_site_url','groundhogg_username','groundhogg_app_password','groundhogg_debug')"
+    );
     $stmt->execute();
     $rows = $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
     return [
         'site_url'  => $rows['groundhogg_site_url'] ?? '',
         'username'  => $rows['groundhogg_username'] ?? '',
-        'app_pass'  => $rows['groundhogg_app_password'] ?? ''
+        'app_pass'  => $rows['groundhogg_app_password'] ?? '',
+        'debug'     => $rows['groundhogg_debug'] ?? ''
     ];
+}
+
+function groundhogg_debug_enabled(): bool {
+    $settings = groundhogg_get_settings();
+    return $settings['debug'] === '1';
+}
+
+function groundhogg_debug_log(string $message): void {
+    if (!groundhogg_debug_enabled()) {
+        return;
+    }
+    $logDir = __DIR__ . '/../logs';
+    if (!is_dir($logDir)) {
+        @mkdir($logDir, 0777, true);
+    }
+    $file = $logDir . '/groundhogg.log';
+    $entry = '[' . date('Y-m-d H:i:s') . "] " . $message . "\n";
+    file_put_contents($file, $entry, FILE_APPEND);
 }
 
 function groundhogg_log(string $message, ?int $store_id = null, string $action = 'groundhogg'): void {
@@ -35,6 +56,8 @@ function groundhogg_send_contact(array $contactData): bool {
     $url = rtrim($settings['site_url'], '/') . '/wp-json/gh/v4/contacts';
     $auth = base64_encode($settings['username'] . ':' . $settings['app_pass']);
 
+    groundhogg_debug_log('POST ' . $url . ' Payload: ' . json_encode($contactData));
+
     $ch = curl_init($url);
     curl_setopt_array($ch, [
         CURLOPT_POST => true,
@@ -46,10 +69,14 @@ function groundhogg_send_contact(array $contactData): bool {
         CURLOPT_POSTFIELDS => json_encode($contactData)
     ]);
     $response = curl_exec($ch);
+    if ($response === false) {
+        groundhogg_debug_log('cURL error: ' . curl_error($ch));
+    }
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
 
     groundhogg_log("POST $url HTTP $httpCode Response: $response", $contactData['store_id'] ?? null, 'groundhogg_contact');
+    groundhogg_debug_log('Response Code: ' . $httpCode . ' Body: ' . $response);
 
     return $httpCode >= 200 && $httpCode < 300;
 }
@@ -62,6 +89,8 @@ function test_groundhogg_connection(): array {
     $url = rtrim($settings['site_url'], '/') . '/wp-json/gh/v4/ping';
     $auth = base64_encode($settings['username'] . ':' . $settings['app_pass']);
 
+    groundhogg_debug_log('GET ' . $url . ' (test connection)');
+
     $ch = curl_init($url);
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,
@@ -70,11 +99,15 @@ function test_groundhogg_connection(): array {
         ]
     ]);
     $response = curl_exec($ch);
+    if ($response === false) {
+        groundhogg_debug_log('cURL error: ' . curl_error($ch));
+    }
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
 
     $success = $httpCode >= 200 && $httpCode < 300;
     groundhogg_log("GET $url HTTP $httpCode Response: $response", null, 'groundhogg_test');
+    groundhogg_debug_log('Response Code: ' . $httpCode . ' Body: ' . $response);
 
     return [$success, $response ?: ''];
 }


### PR DESCRIPTION
## Summary
- add optional debug setting for Groundhogg CRM
- write detailed API logs to `logs/groundhogg.log`
- expose debug option in admin settings
- document debug logging in README

## Testing
- `php -l lib/groundhogg.php`
- `php -l admin/settings.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68757b79247c8326837c22a8f0347c0e