### PR TITLE
Remove legacy WordPress auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,9 @@ The current version is tracked in the `VERSION` file. Run `php scripts/bump_vers
 
 To sync new store contacts with your Groundhogg installation, open **Admin → Settings** and enter the following details under **Groundhogg CRM Integration**:
 
-1. **WordPress Site URL** – the base URL of the site where Groundhogg is installed.
-2. **Groundhogg API Username** – the WordPress user to authenticate with.
-3. **Groundhogg API App Password** – legacy method using a WordPress application password.
-4. **Public Key / Token / Secret Key** – credentials for the advanced API authentication.
+1. **Groundhogg Site URL** – the base URL of the site where Groundhogg is installed. The API endpoints are automatically appended (e.g. `/wp-json/gh/v4`).
+2. **Groundhogg API Username** – the WordPress user associated with your API keys.
+3. **Public Key / Token / Secret Key** – credentials for the advanced API authentication.
 
 After saving, use the **Test Connection** button to verify communication with your Groundhogg REST API. If public key credentials are provided, the advanced authentication method is used.
 

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -46,7 +46,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'max_article_length' => $_POST['max_article_length'] ?? '50000',
         'groundhogg_site_url'     => trim($_POST['groundhogg_site_url'] ?? ''),
         'groundhogg_username'     => trim($_POST['groundhogg_username'] ?? ''),
-        'groundhogg_app_password' => trim($_POST['groundhogg_app_password'] ?? ''),
         'groundhogg_public_key'   => trim($_POST['groundhogg_public_key'] ?? ''),
         'groundhogg_token'        => trim($_POST['groundhogg_token'] ?? ''),
         'groundhogg_secret_key'   => trim($_POST['groundhogg_secret_key'] ?? ''),
@@ -104,7 +103,6 @@ $article_approval_subject = get_setting('article_approval_subject') ?: 'Article 
 $max_article_length = get_setting('max_article_length') ?: '50000';
 $groundhogg_site_url = get_setting('groundhogg_site_url');
 $groundhogg_username = get_setting('groundhogg_username');
-$groundhogg_app_password = get_setting('groundhogg_app_password');
 $groundhogg_public_key = get_setting('groundhogg_public_key');
 $groundhogg_token = get_setting('groundhogg_token');
 $groundhogg_secret_key = get_setting('groundhogg_secret_key');
@@ -206,16 +204,12 @@ include __DIR__.'/header.php';
             </div>
             <div class="card-body">
                 <div class="mb-3">
-                    <label for="groundhogg_site_url" class="form-label">WordPress Site URL</label>
-                    <input type="text" name="groundhogg_site_url" id="groundhogg_site_url" class="form-control" value="<?php echo htmlspecialchars($groundhogg_site_url); ?>" placeholder="https://crm.example.com">
+                    <label for="groundhogg_site_url" class="form-label">Groundhogg Site URL</label>
+                    <input type="text" name="groundhogg_site_url" id="groundhogg_site_url" class="form-control" value="<?php echo htmlspecialchars($groundhogg_site_url); ?>" placeholder="https://www.cosmickmedia.com">
                 </div>
                 <div class="mb-3">
                     <label for="groundhogg_username" class="form-label">Groundhogg API Username</label>
                     <input type="text" name="groundhogg_username" id="groundhogg_username" class="form-control" value="<?php echo htmlspecialchars($groundhogg_username); ?>">
-                </div>
-                <div class="mb-3">
-                    <label for="groundhogg_app_password" class="form-label">Groundhogg API App Password</label>
-                    <input type="password" name="groundhogg_app_password" id="groundhogg_app_password" class="form-control" value="<?php echo htmlspecialchars($groundhogg_app_password); ?>">
                 </div>
                 <div class="mb-3">
                     <label for="groundhogg_public_key" class="form-label">Public Key</label>

--- a/lib/groundhogg.php
+++ b/lib/groundhogg.php
@@ -10,7 +10,6 @@ function groundhogg_get_settings(): array {
         "SELECT name, value FROM settings WHERE name IN (
             'groundhogg_site_url',
             'groundhogg_username',
-            'groundhogg_app_password',
             'groundhogg_public_key',
             'groundhogg_token',
             'groundhogg_secret_key',
@@ -22,7 +21,6 @@ function groundhogg_get_settings(): array {
     return [
         'site_url'   => $rows['groundhogg_site_url'] ?? '',
         'username'   => $rows['groundhogg_username'] ?? '',
-        'app_pass'   => $rows['groundhogg_app_password'] ?? '',
         'public_key' => $rows['groundhogg_public_key'] ?? '',
         'token'      => $rows['groundhogg_token'] ?? '',
         'secret_key' => $rows['groundhogg_secret_key'] ?? '',
@@ -75,9 +73,6 @@ function groundhogg_send_contact(array $contactData): bool {
         $headers[] = 'X-GH-PUBLIC-KEY: ' . $settings['public_key'];
         $headers[] = 'X-GH-TOKEN: ' . $settings['token'];
         $headers[] = 'X-GH-SIGNATURE: ' . $signature;
-    } elseif ($settings['username'] && $settings['app_pass']) {
-        $auth = base64_encode($settings['username'] . ':' . $settings['app_pass']);
-        $headers[] = 'Authorization: Basic ' . $auth;
     } else {
         return false;
     }
@@ -118,9 +113,6 @@ function test_groundhogg_connection(): array {
         $headers[] = 'X-GH-PUBLIC-KEY: ' . $settings['public_key'];
         $headers[] = 'X-GH-TOKEN: ' . $settings['token'];
         $headers[] = 'X-GH-SIGNATURE: ' . $signature;
-    } elseif ($settings['username'] && $settings['app_pass']) {
-        $auth = base64_encode($settings['username'] . ':' . $settings['app_pass']);
-        $headers[] = 'Authorization: Basic ' . $auth;
     } else {
         return [false, 'Missing configuration'];
     }

--- a/update_database.php
+++ b/update_database.php
@@ -13,8 +13,7 @@ echo "Starting database update...\n\n";
 // Migrate old Dripley settings to Groundhogg naming
 $mapping = [
     'dripley_site_url' => 'groundhogg_site_url',
-    'dripley_username' => 'groundhogg_username',
-    'dripley_app_password' => 'groundhogg_app_password'
+    'dripley_username' => 'groundhogg_username'
 ];
 foreach ($mapping as $old => $new) {
     try {


### PR DESCRIPTION
## Summary
- remove WordPress app password authentication
- clean up old references in Groundhogg settings
- update settings UI and docs to show new API URL format

## Testing
- `php -l lib/groundhogg.php`
- `php -l admin/settings.php`
- `php -l update_database.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6875887ed76c83268a0d0d4495dccd3d