### PR TITLE
Allow configuring Groundhogg tags

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -49,7 +49,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'groundhogg_public_key'   => trim($_POST['groundhogg_public_key'] ?? ''),
         'groundhogg_token'        => trim($_POST['groundhogg_token'] ?? ''),
         'groundhogg_secret_key'   => trim($_POST['groundhogg_secret_key'] ?? ''),
-        'groundhogg_debug'        => isset($_POST['groundhogg_debug']) ? '1' : '0'
+        'groundhogg_debug'        => isset($_POST['groundhogg_debug']) ? '1' : '0',
+        'groundhogg_contact_tags' => trim($_POST['groundhogg_contact_tags'] ?? '')
     ];
 
     foreach ($settings as $name => $value) {
@@ -107,6 +108,7 @@ $groundhogg_public_key = get_setting('groundhogg_public_key');
 $groundhogg_token = get_setting('groundhogg_token');
 $groundhogg_secret_key = get_setting('groundhogg_secret_key');
 $groundhogg_debug = get_setting('groundhogg_debug');
+$groundhogg_contact_tags = get_setting('groundhogg_contact_tags');
 
 $active = 'settings';
 include __DIR__.'/header.php';
@@ -228,12 +230,16 @@ include __DIR__.'/header.php';
                     <label for="groundhogg_debug" class="form-check-label">Enable Debug Logging</label>
                     <div class="form-text">Logs API communication to <code>logs/groundhogg.log</code></div>
                 </div>
-                <button class="btn btn-secondary" type="submit" name="test_groundhogg">Test Connection</button>
+                <div class="mb-3">
+                    <label for="groundhogg_contact_tags" class="form-label">Default Contact Tags</label>
+                    <input type="text" name="groundhogg_contact_tags" id="groundhogg_contact_tags" class="form-control" value="<?php echo htmlspecialchars($groundhogg_contact_tags); ?>">
+                    <div class="form-text">Comma-separated tags applied to new contacts</div>
+                </div>
+                <div class="d-flex gap-2">
+                    <button class="btn btn-secondary" type="submit" name="test_groundhogg">Test Connection</button>
+                    <a href="sync_groundhogg.php" class="btn btn-secondary">Sync Contacts</a>
+                </div>
             </div>
-
-            <button class="btn btn-secondary" type="submit" name="test_groundhogg">Test Connection</button>
-            <a href="sync_groundhogg.php" class="btn btn-secondary">Sync All Stores</a>
-
         </div>
 
         <div class="card mb-4">

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -41,7 +41,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'phone'        => $_POST['phone'] ?? '',
                     'company_name' => $_POST['name'] ?? '',
                     'user_role'    => 'Store Admin',
-                    'tags'         => ['media-hub', 'store-onboarding'],
+                    'tags'         => groundhogg_get_default_tags(),
                     'store_id'     => (int)$storeId
                 ];
 

--- a/setup.php
+++ b/setup.php
@@ -291,7 +291,9 @@ $defaultSettings = [
     'notification_email' => $config['notification_email'] ?? '',
     'groundhogg_public_key' => '',
     'groundhogg_token' => '',
-    'groundhogg_secret_key' => ''
+    'groundhogg_secret_key' => '',
+    // Default tags applied to contacts created in Groundhogg
+    'groundhogg_contact_tags' => 'media-hub, store-onboarding'
 ];
 
 foreach ($defaultSettings as $name => $value) {

--- a/update_database.php
+++ b/update_database.php
@@ -31,7 +31,7 @@ foreach ($mapping as $old => $new) {
 }
 
 // Ensure new Groundhogg API settings exist
-$newGhSettings = ['groundhogg_public_key', 'groundhogg_token', 'groundhogg_secret_key'];
+$newGhSettings = ['groundhogg_public_key', 'groundhogg_token', 'groundhogg_secret_key', 'groundhogg_contact_tags'];
 foreach ($newGhSettings as $setting) {
     try {
         $stmt = $pdo->prepare("SELECT COUNT(*) FROM settings WHERE name = ?");
@@ -51,7 +51,9 @@ $defaultSettings = [
     'email_from_address' => 'noreply@cosmickmedia.com',
     'admin_notification_subject' => 'New uploads from {store_name}',
     'store_notification_subject' => 'Content Submission Confirmation - Cosmick Media',
-    'store_message_subject' => 'New message from Cosmick Media'
+    'store_message_subject' => 'New message from Cosmick Media',
+    // Default tags for Groundhogg contacts
+    'groundhogg_contact_tags' => 'media-hub, store-onboarding'
 ];
 
 foreach ($defaultSettings as $name => $value) {


### PR DESCRIPTION
## Summary
- make default Groundhogg tags configurable in settings
- add contact tags field to settings page and clean duplicate buttons
- use configurable tags when syncing contacts
- fix success message logic in `edit_store.php`
- set default tags in setup and database update scripts

## Testing
- `php -l admin/edit_store.php`
- `php -l admin/stores.php`
- `php -l admin/settings.php`
- `php -l lib/groundhogg.php`
- `php -l setup.php`
- `php -l update_database.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687599d271bc8326a9ff379dd745fa45