### PR TITLE
Improve settings UI and deduplicate statuses

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -124,199 +124,212 @@ include __DIR__.'/header.php';
 <?php endif; ?>
 <?php if ($test_result !== null): ?>
     <?php if ($test_result[0]): ?>
-        <div class="alert alert-success alert-dismissible fade show" role="alert">Groundhogg connection successful!
+        <div class="alert alert-success alert-dismissible fade show" role="alert">Dripley connection successful!
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         </div>
     <?php else: ?>
-        <div class="alert alert-danger alert-dismissible fade show" role="alert">Groundhogg connection failed: <?php echo htmlspecialchars($test_result[1]); ?>
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">Dripley connection failed: <?php echo htmlspecialchars($test_result[1]); ?>
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         </div>
     <?php endif; ?>
 <?php endif; ?>
 
     <form method="post" enctype="multipart/form-data">
-        <div class="row">
-            <div class="col-lg-6">
+        <ul class="nav nav-tabs" id="settingsTabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link active" id="general-tab" data-bs-toggle="tab" data-bs-target="#general" type="button" role="tab">General</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="dripley-tab" data-bs-toggle="tab" data-bs-target="#dripley" type="button" role="tab">Dripley CRM</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="subjects-tab" data-bs-toggle="tab" data-bs-target="#subjects" type="button" role="tab">Email Subjects</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="statuses-tab" data-bs-toggle="tab" data-bs-target="#statuses" type="button" role="tab">Upload Statuses</button>
+            </li>
+        </ul>
+        <div class="tab-content pt-3">
+            <div class="tab-pane fade show active" id="general" role="tabpanel" aria-labelledby="general-tab">
+                <div class="row">
+                    <div class="col-lg-6">
+                        <div class="card mb-4">
+                            <div class="card-header">
+                                <h5 class="mb-0">Google Drive Settings</h5>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <label class="form-label">Service Account JSON</label>
+                                    <input class="form-control" type="file" name="sa_json" accept=".json">
+                                    <div class="form-text">Upload Google service account credentials file</div>
+                                </div>
+                                <div class="mb-3">
+                                    <label for="drive_folder" class="form-label">Base Drive Folder ID</label>
+                                    <input type="text" name="drive_folder" id="drive_folder" class="form-control" value="<?php echo htmlspecialchars($drive_folder); ?>">
+                                    <div class="form-text">The Google Drive folder ID where store folders will be created</div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="card mb-4">
+                            <div class="card-header">
+                                <h5 class="mb-0">Article Settings</h5>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <label for="max_article_length" class="form-label">Maximum Article Length (characters)</label>
+                                    <input type="number" name="max_article_length" id="max_article_length" class="form-control" value="<?php echo htmlspecialchars($max_article_length); ?>">
+                                    <div class="form-text">Maximum character count allowed for article submissions</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col-lg-6">
+                        <div class="card mb-4">
+                            <div class="card-header">
+                                <h5 class="mb-0">Email Settings</h5>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <label for="notify_email" class="form-label">Admin Notification Email(s)</label>
+                                    <input type="text" name="notify_email" id="notify_email" class="form-control" value="<?php echo htmlspecialchars($notify_email); ?>">
+                                    <div class="form-text">Comma-separated emails for upload and article notifications</div>
+                                </div>
+                                <div class="mb-3">
+                                    <label for="email_from_name" class="form-label">From Name</label>
+                                    <input type="text" name="email_from_name" id="email_from_name" class="form-control" value="<?php echo htmlspecialchars($email_from_name); ?>">
+                                    <div class="form-text">Name shown in email "From" field</div>
+                                </div>
+                                <div class="mb-3">
+                                    <label for="email_from_address" class="form-label">From Email Address</label>
+                                    <input type="email" name="email_from_address" id="email_from_address" class="form-control" value="<?php echo htmlspecialchars($email_from_address); ?>">
+                                    <div class="form-text">Email address used for sending</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="tab-pane fade" id="dripley" role="tabpanel" aria-labelledby="dripley-tab">
                 <div class="card mb-4">
                     <div class="card-header">
-                        <h5 class="mb-0">Google Drive Settings</h5>
+                        <h5 class="mb-0">Dripley CRM Integration</h5>
                     </div>
                     <div class="card-body">
                         <div class="mb-3">
-                            <label class="form-label">Service Account JSON</label>
-                            <input class="form-control" type="file" name="sa_json" accept=".json">
-                            <div class="form-text">Upload Google service account credentials file</div>
+                            <label for="groundhogg_site_url" class="form-label">Dripley Site URL</label>
+                            <input type="text" name="groundhogg_site_url" id="groundhogg_site_url" class="form-control" value="<?php echo htmlspecialchars($groundhogg_site_url); ?>" placeholder="https://www.cosmickmedia.com">
                         </div>
                         <div class="mb-3">
-                            <label for="drive_folder" class="form-label">Base Drive Folder ID</label>
-                            <input type="text" name="drive_folder" id="drive_folder" class="form-control"
-                                   value="<?php echo htmlspecialchars($drive_folder); ?>">
-                            <div class="form-text">The Google Drive folder ID where store folders will be created</div>
+                            <label for="groundhogg_username" class="form-label">Dripley API Username</label>
+                            <input type="text" name="groundhogg_username" id="groundhogg_username" class="form-control" value="<?php echo htmlspecialchars($groundhogg_username); ?>">
+                        </div>
+                        <div class="mb-3">
+                            <label for="groundhogg_public_key" class="form-label">Public Key</label>
+                            <input type="text" name="groundhogg_public_key" id="groundhogg_public_key" class="form-control" value="<?php echo htmlspecialchars($groundhogg_public_key); ?>">
+                        </div>
+                        <div class="mb-3">
+                            <label for="groundhogg_token" class="form-label">Token</label>
+                            <input type="text" name="groundhogg_token" id="groundhogg_token" class="form-control" value="<?php echo htmlspecialchars($groundhogg_token); ?>">
+                        </div>
+                        <div class="mb-3">
+                            <label for="groundhogg_secret_key" class="form-label">Secret Key</label>
+                            <input type="text" name="groundhogg_secret_key" id="groundhogg_secret_key" class="form-control" value="<?php echo htmlspecialchars($groundhogg_secret_key); ?>">
+                        </div>
+                        <div class="form-check mb-3">
+                            <input type="checkbox" name="groundhogg_debug" id="groundhogg_debug" class="form-check-input" value="1" <?php if ($groundhogg_debug === '1') echo 'checked'; ?>>
+                            <label for="groundhogg_debug" class="form-check-label">Enable Debug Logging</label>
+                            <div class="form-text">Logs API communication to <code>logs/groundhogg.log</code></div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="groundhogg_contact_tags" class="form-label">Default Contact Tags</label>
+                            <input type="text" name="groundhogg_contact_tags" id="groundhogg_contact_tags" class="form-control" value="<?php echo htmlspecialchars($groundhogg_contact_tags); ?>">
+                            <div class="form-text">Comma-separated tags applied to new contacts</div>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <button class="btn btn-secondary" type="submit" name="test_groundhogg">Test Connection</button>
+                            <a href="sync_groundhogg.php" class="btn btn-secondary">Sync Contacts</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="tab-pane fade" id="subjects" role="tabpanel" aria-labelledby="subjects-tab">
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="mb-0">Email Subject Lines - Uploads</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label for="admin_notification_subject" class="form-label">Admin Notification Subject (New Uploads)</label>
+                            <input type="text" name="admin_notification_subject" id="admin_notification_subject" class="form-control" value="<?php echo htmlspecialchars($admin_notification_subject); ?>">
+                            <div class="form-text">Subject for emails sent to admin when new content is uploaded. Use {store_name} as placeholder.</div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="store_notification_subject" class="form-label">Store Confirmation Subject (Upload Confirmation)</label>
+                            <input type="text" name="store_notification_subject" id="store_notification_subject" class="form-control" value="<?php echo htmlspecialchars($store_notification_subject); ?>">
+                            <div class="form-text">Subject for confirmation emails sent to stores after upload. Use {store_name} as placeholder.</div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="store_message_subject" class="form-label">Store Message Subject (Admin Messages)</label>
+                            <input type="text" name="store_message_subject" id="store_message_subject" class="form-control" value="<?php echo htmlspecialchars($store_message_subject); ?>">
+                            <div class="form-text">Subject for emails sent to stores when admin posts a message. Use {store_name} as placeholder.</div>
                         </div>
                     </div>
                 </div>
 
                 <div class="card mb-4">
                     <div class="card-header">
-                        <h5 class="mb-0">Article Settings</h5>
+                        <h5 class="mb-0">Email Subject Lines - Articles</h5>
                     </div>
                     <div class="card-body">
                         <div class="mb-3">
-                            <label for="max_article_length" class="form-label">Maximum Article Length (characters)</label>
-                            <input type="number" name="max_article_length" id="max_article_length" class="form-control"
-                                   value="<?php echo htmlspecialchars($max_article_length); ?>">
-                            <div class="form-text">Maximum character count allowed for article submissions</div>
+                            <label for="admin_article_notification_subject" class="form-label">Admin Notification Subject (New Articles)</label>
+                            <input type="text" name="admin_article_notification_subject" id="admin_article_notification_subject" class="form-control" value="<?php echo htmlspecialchars($admin_article_notification_subject); ?>">
+                            <div class="form-text">Subject for emails sent to admin when new article is submitted. Use {store_name} as placeholder.</div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="store_article_notification_subject" class="form-label">Store Confirmation Subject (Article Submission)</label>
+                            <input type="text" name="store_article_notification_subject" id="store_article_notification_subject" class="form-control" value="<?php echo htmlspecialchars($store_article_notification_subject); ?>">
+                            <div class="form-text">Subject for confirmation emails sent to stores after article submission. Use {store_name} as placeholder.</div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="article_approval_subject" class="form-label">Article Status Update Subject</label>
+                            <input type="text" name="article_approval_subject" id="article_approval_subject" class="form-control" value="<?php echo htmlspecialchars($article_approval_subject); ?>">
+                            <div class="form-text">Subject for emails sent when article status is updated. Use {store_name} as placeholder.</div>
                         </div>
                     </div>
                 </div>
             </div>
 
-            <div class="col-lg-6">
+            <div class="tab-pane fade" id="statuses" role="tabpanel" aria-labelledby="statuses-tab">
                 <div class="card mb-4">
                     <div class="card-header">
-                        <h5 class="mb-0">Email Settings</h5>
+                        <h5 class="mb-0">Upload Statuses</h5>
                     </div>
                     <div class="card-body">
-                        <div class="mb-3">
-                            <label for="notify_email" class="form-label">Admin Notification Email(s)</label>
-                            <input type="text" name="notify_email" id="notify_email" class="form-control"
-                                   value="<?php echo htmlspecialchars($notify_email); ?>">
-                            <div class="form-text">Comma-separated emails for upload and article notifications</div>
-                        </div>
-                        <div class="mb-3">
-                            <label for="email_from_name" class="form-label">From Name</label>
-                            <input type="text" name="email_from_name" id="email_from_name" class="form-control"
-                                   value="<?php echo htmlspecialchars($email_from_name); ?>">
-                            <div class="form-text">Name shown in email "From" field</div>
-                        </div>
-                        <div class="mb-3">
-                            <label for="email_from_address" class="form-label">From Email Address</label>
-                            <input type="email" name="email_from_address" id="email_from_address" class="form-control"
-                                   value="<?php echo htmlspecialchars($email_from_address); ?>">
-                            <div class="form-text">Email address used for sending</div>
-                        </div>
+                        <table class="table" id="statusTable">
+                            <thead>
+                            <tr><th>Name</th><th>Color</th><th></th></tr>
+                            </thead>
+                            <tbody>
+                            <?php foreach ($statuses as $st): ?>
+                                <tr>
+                                    <td>
+                                        <input type="hidden" name="status_id[]" value="<?php echo $st['id']; ?>">
+                                        <input type="text" name="status_name[]" class="form-control" value="<?php echo htmlspecialchars($st['name']); ?>">
+                                    </td>
+                                    <td><input type="color" name="status_color[]" class="form-control form-control-color" value="<?php echo htmlspecialchars($st['color']); ?>"></td>
+                                    <td><button type="button" class="btn btn-sm btn-danger remove-status">Delete</button></td>
+                                </tr>
+                            <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                        <button type="button" class="btn btn-sm btn-secondary" id="addStatus">Add Status</button>
                     </div>
                 </div>
-            </div>
-        </div>
-
-        <div class="card mb-4">
-        <div class="card-header">
-                <h5 class="mb-0">Groundhogg CRM Integration</h5>
-            </div>
-            <div class="card-body">
-                <div class="mb-3">
-                    <label for="groundhogg_site_url" class="form-label">Groundhogg Site URL</label>
-                    <input type="text" name="groundhogg_site_url" id="groundhogg_site_url" class="form-control" value="<?php echo htmlspecialchars($groundhogg_site_url); ?>" placeholder="https://www.cosmickmedia.com">
-                </div>
-                <div class="mb-3">
-                    <label for="groundhogg_username" class="form-label">Groundhogg API Username</label>
-                    <input type="text" name="groundhogg_username" id="groundhogg_username" class="form-control" value="<?php echo htmlspecialchars($groundhogg_username); ?>">
-                </div>
-                <div class="mb-3">
-                    <label for="groundhogg_public_key" class="form-label">Public Key</label>
-                    <input type="text" name="groundhogg_public_key" id="groundhogg_public_key" class="form-control" value="<?php echo htmlspecialchars($groundhogg_public_key); ?>">
-                </div>
-                <div class="mb-3">
-                    <label for="groundhogg_token" class="form-label">Token</label>
-                    <input type="text" name="groundhogg_token" id="groundhogg_token" class="form-control" value="<?php echo htmlspecialchars($groundhogg_token); ?>">
-                </div>
-                <div class="mb-3">
-                    <label for="groundhogg_secret_key" class="form-label">Secret Key</label>
-                    <input type="text" name="groundhogg_secret_key" id="groundhogg_secret_key" class="form-control" value="<?php echo htmlspecialchars($groundhogg_secret_key); ?>">
-                </div>
-                <div class="form-check mb-3">
-                    <input type="checkbox" name="groundhogg_debug" id="groundhogg_debug" class="form-check-input" value="1" <?php if ($groundhogg_debug === '1') echo 'checked'; ?>>
-                    <label for="groundhogg_debug" class="form-check-label">Enable Debug Logging</label>
-                    <div class="form-text">Logs API communication to <code>logs/groundhogg.log</code></div>
-                </div>
-                <div class="mb-3">
-                    <label for="groundhogg_contact_tags" class="form-label">Default Contact Tags</label>
-                    <input type="text" name="groundhogg_contact_tags" id="groundhogg_contact_tags" class="form-control" value="<?php echo htmlspecialchars($groundhogg_contact_tags); ?>">
-                    <div class="form-text">Comma-separated tags applied to new contacts</div>
-                </div>
-                <div class="d-flex gap-2">
-                    <button class="btn btn-secondary" type="submit" name="test_groundhogg">Test Connection</button>
-                    <a href="sync_groundhogg.php" class="btn btn-secondary">Sync Contacts</a>
-                </div>
-            </div>
-        </div>
-
-        <div class="card mb-4">
-            <div class="card-header">
-                <h5 class="mb-0">Email Subject Lines - Uploads</h5>
-            </div>
-            <div class="card-body">
-                <div class="mb-3">
-                    <label for="admin_notification_subject" class="form-label">Admin Notification Subject (New Uploads)</label>
-                    <input type="text" name="admin_notification_subject" id="admin_notification_subject" class="form-control"
-                           value="<?php echo htmlspecialchars($admin_notification_subject); ?>">
-                    <div class="form-text">Subject for emails sent to admin when new content is uploaded. Use {store_name} as placeholder.</div>
-                </div>
-                <div class="mb-3">
-                    <label for="store_notification_subject" class="form-label">Store Confirmation Subject (Upload Confirmation)</label>
-                    <input type="text" name="store_notification_subject" id="store_notification_subject" class="form-control"
-                           value="<?php echo htmlspecialchars($store_notification_subject); ?>">
-                    <div class="form-text">Subject for confirmation emails sent to stores after upload. Use {store_name} as placeholder.</div>
-                </div>
-                <div class="mb-3">
-                    <label for="store_message_subject" class="form-label">Store Message Subject (Admin Messages)</label>
-                    <input type="text" name="store_message_subject" id="store_message_subject" class="form-control"
-                           value="<?php echo htmlspecialchars($store_message_subject); ?>">
-                    <div class="form-text">Subject for emails sent to stores when admin posts a message. Use {store_name} as placeholder.</div>
-                </div>
-            </div>
-        </div>
-
-        <div class="card mb-4">
-            <div class="card-header">
-                <h5 class="mb-0">Email Subject Lines - Articles</h5>
-            </div>
-            <div class="card-body">
-                <div class="mb-3">
-                    <label for="admin_article_notification_subject" class="form-label">Admin Notification Subject (New Articles)</label>
-                    <input type="text" name="admin_article_notification_subject" id="admin_article_notification_subject" class="form-control"
-                           value="<?php echo htmlspecialchars($admin_article_notification_subject); ?>">
-                    <div class="form-text">Subject for emails sent to admin when new article is submitted. Use {store_name} as placeholder.</div>
-                </div>
-                <div class="mb-3">
-                    <label for="store_article_notification_subject" class="form-label">Store Confirmation Subject (Article Submission)</label>
-                    <input type="text" name="store_article_notification_subject" id="store_article_notification_subject" class="form-control"
-                           value="<?php echo htmlspecialchars($store_article_notification_subject); ?>">
-                    <div class="form-text">Subject for confirmation emails sent to stores after article submission. Use {store_name} as placeholder.</div>
-                </div>
-                <div class="mb-3">
-                    <label for="article_approval_subject" class="form-label">Article Status Update Subject</label>
-                    <input type="text" name="article_approval_subject" id="article_approval_subject" class="form-control"
-                           value="<?php echo htmlspecialchars($article_approval_subject); ?>">
-                    <div class="form-text">Subject for emails sent when article status is updated. Use {store_name} as placeholder.</div>
-                </div>
-            </div>
-        </div>
-
-        <div class="card mb-4">
-            <div class="card-header">
-                <h5 class="mb-0">Upload Statuses</h5>
-            </div>
-            <div class="card-body">
-                <table class="table" id="statusTable">
-                    <thead>
-                    <tr><th>Name</th><th>Color</th><th></th></tr>
-                    </thead>
-                    <tbody>
-                    <?php foreach ($statuses as $st): ?>
-                        <tr>
-                            <td>
-                                <input type="hidden" name="status_id[]" value="<?php echo $st['id']; ?>">
-                                <input type="text" name="status_name[]" class="form-control" value="<?php echo htmlspecialchars($st['name']); ?>">
-                            </td>
-                            <td><input type="color" name="status_color[]" class="form-control form-control-color" value="<?php echo htmlspecialchars($st['color']); ?>"></td>
-                            <td><button type="button" class="btn btn-sm btn-danger remove-status">Delete</button></td>
-                        </tr>
-                    <?php endforeach; ?>
-                    </tbody>
-                </table>
-                <button type="button" class="btn btn-sm btn-secondary" id="addStatus">Add Status</button>
             </div>
         </div>
 

--- a/cmuploader.sql
+++ b/cmuploader.sql
@@ -222,7 +222,8 @@ INSERT INTO `uploads` (`id`, `store_id`, `filename`, `description`, `custom_mess
 CREATE TABLE `upload_statuses` (
   `id` int(11) NOT NULL,
   `name` varchar(100) NOT NULL,
-  `color` varchar(20) NOT NULL
+  `color` varchar(20) NOT NULL,
+  UNIQUE KEY `name_unique` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
@@ -232,16 +233,7 @@ CREATE TABLE `upload_statuses` (
 INSERT INTO `upload_statuses` (`id`, `name`, `color`) VALUES
 (1, 'Reviewed', '#198754'),
 (2, 'Pending Submission', '#ffc107'),
-(3, 'Scheduled', '#0dcaf0'),
-(4, 'Reviewed', '#198754'),
-(5, 'Pending Submission', '#ffc107'),
-(6, 'Scheduled', '#0dcaf0'),
-(7, 'Reviewed', '#198754'),
-(8, 'Pending Submission', '#ffc107'),
-(9, 'Scheduled', '#0dcaf0'),
-(10, 'Reviewed', '#198754'),
-(11, 'Pending Submission', '#ffc107'),
-(12, 'Scheduled', '#0dcaf0');
+(3, 'Scheduled', '#0dcaf0');
 
 -- --------------------------------------------------------
 
@@ -328,7 +320,8 @@ ALTER TABLE `uploads`
 -- Indexes for table `upload_statuses`
 --
 ALTER TABLE `upload_statuses`
-  ADD PRIMARY KEY (`id`);
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `name_unique` (`name`);
 
 --
 -- Indexes for table `users`
@@ -387,7 +380,7 @@ ALTER TABLE `uploads`
 -- AUTO_INCREMENT for table `upload_statuses`
 --
 ALTER TABLE `upload_statuses`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=13;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;
 
 --
 -- AUTO_INCREMENT for table `users`

--- a/setup.php
+++ b/setup.php
@@ -99,7 +99,8 @@ $queries = [
     "CREATE TABLE IF NOT EXISTS upload_statuses (
         id INT AUTO_INCREMENT PRIMARY KEY,
         name VARCHAR(100) NOT NULL,
-        color VARCHAR(20) NOT NULL
+        color VARCHAR(20) NOT NULL,
+        UNIQUE KEY name_unique (name)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
 
     // Upload status history table
@@ -266,7 +267,7 @@ $defaultStatuses = [
 ];
 foreach ($defaultStatuses as $st) {
     try {
-        $stmt = $pdo->prepare("INSERT IGNORE INTO upload_statuses (name, color) VALUES (?, ?)");
+        $stmt = $pdo->prepare("INSERT INTO upload_statuses (name, color) VALUES (?, ?) ON DUPLICATE KEY UPDATE color=VALUES(color)");
         $stmt->execute($st);
     } catch (PDOException $e) {
         // Ignore if exists

--- a/update_database.php
+++ b/update_database.php
@@ -234,7 +234,8 @@ try {
     $pdo->exec("CREATE TABLE IF NOT EXISTS upload_statuses (
         id INT AUTO_INCREMENT PRIMARY KEY,
         name VARCHAR(100) NOT NULL,
-        color VARCHAR(20) NOT NULL
+        color VARCHAR(20) NOT NULL,
+        UNIQUE KEY name_unique (name)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
     echo "✓ Created upload_statuses table\n";
 } catch (PDOException $e) {
@@ -258,7 +259,7 @@ $defaultStatuses = [
 ];
 foreach ($defaultStatuses as $st) {
     try {
-        $stmt = $pdo->prepare("INSERT IGNORE INTO upload_statuses (name, color) VALUES (?, ?)");
+        $stmt = $pdo->prepare("INSERT INTO upload_statuses (name, color) VALUES (?, ?) ON DUPLICATE KEY UPDATE color=VALUES(color)");
         $stmt->execute($st);
     } catch (PDOException $e) {
         // ignore


### PR DESCRIPTION
## Summary
- white label Groundhogg text to Dripley in settings UI
- organize settings in Bootstrap tabs for easier navigation
- add unique constraint for upload_statuses and prevent duplicates
- update SQL dump with clean statuses

## Testing
- `php -l admin/settings.php`
- `php -l update_database.php`
- `php -l setup.php`


------
https://chatgpt.com/codex/tasks/task_e_68759f59713483268586c1c3c8313656