### PR TITLE
Enhance admin UI and Groundhogg sync

### DIFF
--- a/admin/edit_message.php
+++ b/admin/edit_message.php
@@ -1,0 +1,63 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/auth.php';
+require_once __DIR__.'/../lib/helpers.php';
+require_login();
+$pdo = get_pdo();
+
+$id = intval($_GET['id'] ?? 0);
+$stmt = $pdo->prepare('SELECT * FROM store_messages WHERE id = ?');
+$stmt->execute([$id]);
+$message = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$message) {
+    header('Location: messages.php');
+    exit;
+}
+
+$errors = [];
+$success = false;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save'])) {
+    $text = sanitize_message($_POST['message'] ?? '');
+    if ($text === '') {
+        $errors[] = 'Message cannot be empty';
+    } else {
+        $upd = $pdo->prepare('UPDATE store_messages SET message=? WHERE id=?');
+        $upd->execute([$text, $id]);
+        $success = true;
+        $message['message'] = $text;
+    }
+}
+
+$active = 'messages';
+include __DIR__.'/header.php';
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h4>Edit Broadcast</h4>
+    <a href="messages.php" class="btn btn-sm btn-outline-secondary">Back</a>
+</div>
+<?php foreach ($errors as $e): ?>
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        <?php echo htmlspecialchars($e); ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+<?php endforeach; ?>
+<?php if ($success): ?>
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        Message updated successfully
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+<?php endif; ?>
+<div class="card">
+    <div class="card-body">
+        <form method="post">
+            <div class="mb-3">
+                <label class="form-label">Message</label>
+                <textarea name="message" class="form-control" rows="4" required><?php echo htmlspecialchars($message['message']); ?></textarea>
+            </div>
+            <button class="btn btn-primary" name="save" type="submit">Save Changes</button>
+        </form>
+    </div>
+</div>
+<?php include __DIR__.'/footer.php'; ?>

--- a/admin/edit_user.php
+++ b/admin/edit_user.php
@@ -2,6 +2,7 @@
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
 require_once __DIR__.'/../lib/helpers.php';
+require_once __DIR__.'/../lib/groundhogg.php';
 require_login();
 $pdo = get_pdo();
 
@@ -34,6 +35,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_user'])) {
         } else {
             $stmt = $pdo->prepare('UPDATE users SET username=?, first_name=?, last_name=?, email=? WHERE id=?');
             $stmt->execute([$username, $first ?: null, $last ?: null, $email, $id]);
+        }
+        $contact = [
+            'email'       => $email,
+            'first_name'  => $first,
+            'last_name'   => $last,
+            'user_role'   => 'Admin User',
+            'company_name'=> 'Cosmick Media',
+            'tags'        => groundhogg_get_default_tags()
+        ];
+        [$ghSuccess, $ghMessage] = groundhogg_send_contact($contact);
+        if (!$ghSuccess) {
+            $errors[] = 'Groundhogg sync failed: ' . $ghMessage;
         }
         $success = true;
         $stmt = $pdo->prepare('SELECT * FROM users WHERE id = ?');

--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -40,3 +40,11 @@ a:hover { color: #1a252f; }
 .login-page .btn-login { background-color: #ff675b; border-color: #ff675b; color: white; }
 .login-page .btn-login:hover { background-color: #e55750; border-color: #e55750; color: white; }
 
+/* Settings tab font color */
+.nav-tabs .nav-link {
+    color: #2c3e50;
+}
+.nav-tabs .nav-link.active {
+    color: #2c3e50;
+}
+

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -146,7 +146,7 @@ include __DIR__.'/header.php';
                 <button class="nav-link" id="subjects-tab" data-bs-toggle="tab" data-bs-target="#subjects" type="button" role="tab">Email Subjects</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="statuses-tab" data-bs-toggle="tab" data-bs-target="#statuses" type="button" role="tab">Upload Statuses</button>
+                <button class="nav-link" id="statuses-tab" data-bs-toggle="tab" data-bs-target="#statuses" type="button" role="tab">Statuses</button>
             </li>
         </ul>
         <div class="tab-content pt-3">
@@ -307,7 +307,7 @@ include __DIR__.'/header.php';
             <div class="tab-pane fade" id="statuses" role="tabpanel" aria-labelledby="statuses-tab">
                 <div class="card mb-4">
                     <div class="card-header">
-                        <h5 class="mb-0">Upload Statuses</h5>
+                        <h5 class="mb-0">Statuses</h5>
                     </div>
                     <div class="card-body">
                         <table class="table" id="statusTable">

--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -273,7 +273,7 @@ include __DIR__.'/header.php';
             $isOld = $hoursAgo > 168; // 7 days
             $isVideo = strpos($r['mime'], 'video') !== false;
             ?>
-            <div class="col-12 col-md-6 col-lg-4 mb-4">
+            <div class="col-12 col-md-6 col-lg-3 mb-4">
                 <div class="card upload-card <?php echo $isOld ? 'opacity-75' : ''; ?>">
                     <?php if ($r['status_name']): ?>
                         <span class="position-absolute top-0 start-0 m-2 badge" style="background-color: <?php echo htmlspecialchars($r['status_color']); ?>;">
@@ -296,11 +296,11 @@ include __DIR__.'/header.php';
                     <?php endif; ?>
 
                     <div class="card-body">
-                        <h6 class="card-title text-truncate" title="<?php echo htmlspecialchars($r['filename']); ?>">
+                        <h6 class="card-title text-truncate mb-1" title="<?php echo htmlspecialchars($r['filename']); ?>">
                             <?php echo htmlspecialchars(shorten_filename($r['filename'])); ?>
                         </h6>
 
-                        <p class="card-text">
+                        <p class="card-text mb-2">
                             <strong class="text-primary"><?php echo htmlspecialchars($r['store_name']); ?></strong><br>
                             <small class="text-muted">
                                 <?php echo format_ts($r['created_at']); ?><br>
@@ -321,7 +321,7 @@ include __DIR__.'/header.php';
                             </p>
                         <?php endif; ?>
 
-                        <form method="post" class="mt-2">
+                        <form method="post" class="mt-2 mb-3">
                             <input type="hidden" name="set_status" value="1">
                             <input type="hidden" name="upload_id" value="<?php echo $r['id']; ?>">
                             <select name="status_id" class="form-select form-select-sm" onchange="this.form.submit()">


### PR DESCRIPTION
## Summary
- style settings tabs with new font color
- rename *Upload Statuses* tab to *Statuses*
- tweak Content Review grid spacing and switch to four columns
- sync admin users to Groundhogg on create/update
- clean up Broadcasts UI, add edit page and pagination

## Testing
- `php -l admin/edit_user.php`
- `php -l admin/messages.php`
- `php -l admin/settings.php`
- `php -l admin/uploads.php`
- `php -l admin/users.php`
- `php -l admin/edit_message.php`

------
https://chatgpt.com/codex/tasks/task_e_6875a51fd374832685c501998e8408d6