### PR TITLE
Improve admin UI with pastel theme and reset tools

### DIFF
--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -23,8 +23,8 @@ a:hover { color: #1a252f; }
 #messages { max-height: 400px; overflow-y: auto; }
 #messages .mine { text-align: right; }
 #messages .bubble { display:inline-block; padding:6px 12px; border-radius:12px; margin-bottom:4px; max-width:70%; }
-#messages .mine .bubble { background:#d1e7dd; }
-#messages .theirs .bubble { background:#e2e3e5; }
+#messages .mine .bubble { background:#E6FAF1; }
+#messages .theirs .bubble { background:#E8F0FE; }
 #emojiPicker { display:none; position:absolute; bottom:60px; right:20px; }
 .preview-col-sm { width: 60px; }
 .preview-img-sm { width: 50px; height: 50px; object-fit: cover; }
@@ -48,3 +48,12 @@ a:hover { color: #1a252f; }
     color: #2c3e50;
 }
 
+/* Pastel palette */
+.bg-pastel-blue { background-color: #E8F0FE !important; }
+.bg-pastel-yellow { background-color: #FEF7E1 !important; }
+.bg-pastel-mint { background-color: #E6FAF1 !important; }
+.bg-pastel-peach { background-color: #FFF1E6 !important; }
+.bg-pastel-pink { background-color: #FDE8E6 !important; }
+.text-like { color: #E8F0FE !important; }
+.text-love { color: #FDE8E6 !important; }
+#messages .bubble.broadcast { background:#FDE8E6; }

--- a/admin/index.php
+++ b/admin/index.php
@@ -180,7 +180,7 @@ include __DIR__.'/header.php';
     <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 row-cols-xl-5 g-3 mb-4">
         <div class="col">
             <a href="stores.php" class="text-decoration-none">
-                <div class="card text-white bg-primary clickable-card">
+                <div class="card bg-pastel-blue clickable-card">
                     <div class="card-body">
                         <h5 class="card-title">
                             <i class="bi bi-shop"></i> Total Stores
@@ -192,7 +192,7 @@ include __DIR__.'/header.php';
         </div>
         <div class="col">
             <a href="uploads.php" class="text-decoration-none">
-                <div class="card text-white bg-success clickable-card">
+                <div class="card bg-pastel-yellow clickable-card">
                     <div class="card-body">
                         <h5 class="card-title">
                             <i class="bi bi-cloud-upload"></i> Total Uploads
@@ -204,7 +204,7 @@ include __DIR__.'/header.php';
         </div>
         <div class="col">
             <a href="articles.php" class="text-decoration-none">
-                <div class="card text-white bg-info clickable-card">
+                <div class="card bg-pastel-mint clickable-card">
                     <div class="card-body">
                         <h5 class="card-title">
                             <i class="bi bi-file-text"></i> Articles
@@ -221,7 +221,7 @@ include __DIR__.'/header.php';
         </div>
         <div class="col">
             <a href="messages.php" class="text-decoration-none">
-                <div class="card text-white bg-warning clickable-card">
+                <div class="card bg-pastel-peach clickable-card">
                     <div class="card-body">
                         <h5 class="card-title">
                             <i class="bi bi-chat-dots"></i> Active Messages
@@ -233,7 +233,7 @@ include __DIR__.'/header.php';
         </div>
         <div class="col">
             <a href="stores.php" class="text-decoration-none">
-                <div class="card text-white bg-secondary clickable-card">
+                <div class="card bg-pastel-pink clickable-card">
                     <div class="card-body">
                         <h5 class="card-title">
                             <i class="bi bi-people"></i> Store Users
@@ -375,6 +375,33 @@ include __DIR__.'/header.php';
         <div class="col-lg-4">
             <div class="card mb-3">
                 <div class="card-header">
+                    <h5 class="mb-0">Quick Actions</h5>
+                </div>
+                <div class="card-body">
+                    <div class="d-grid gap-2">
+                        <a href="stores.php" class="btn btn-primary">
+                            <i class="bi bi-shop"></i> Manage Stores
+                        </a>
+                        <a href="uploads.php" class="btn btn-primary">
+                            <i class="bi bi-cloud-upload"></i> Review Uploads
+                        </a>
+                        <a href="articles.php" class="btn btn-primary">
+                            <i class="bi bi-file-text"></i> Review Articles
+                            <?php if ($stats['pending_articles'] > 0): ?>
+                                <span class="badge bg-danger"><?php echo $stats['pending_articles']; ?></span>
+                            <?php endif; ?>
+                        </a>
+                        <a href="messages.php" class="btn btn-primary">
+                            <i class="bi bi-chat-dots"></i> Post Messages
+                        </a>
+                        <a href="settings.php" class="btn btn-primary">
+                            <i class="bi bi-gear"></i> Settings
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-header">
                     <h5 class="mb-0">Quick Broadcast</h5>
                 </div>
                 <div class="card-body">
@@ -404,33 +431,6 @@ include __DIR__.'/header.php';
                         </div>
                         <button class="btn btn-primary w-100" type="submit">Send</button>
                     </form>
-                </div>
-            </div>
-            <div class="card">
-                <div class="card-header">
-                    <h5 class="mb-0">Quick Actions</h5>
-                </div>
-                <div class="card-body">
-                    <div class="d-grid gap-2">
-                        <a href="stores.php" class="btn btn-primary">
-                            <i class="bi bi-shop"></i> Manage Stores
-                        </a>
-                        <a href="uploads.php" class="btn btn-primary">
-                            <i class="bi bi-cloud-upload"></i> Review Uploads
-                        </a>
-                        <a href="articles.php" class="btn btn-primary">
-                            <i class="bi bi-file-text"></i> Review Articles
-                            <?php if ($stats['pending_articles'] > 0): ?>
-                                <span class="badge bg-danger"><?php echo $stats['pending_articles']; ?></span>
-                            <?php endif; ?>
-                        </a>
-                        <a href="messages.php" class="btn btn-primary">
-                            <i class="bi bi-chat-dots"></i> Post Messages
-                        </a>
-                        <a href="settings.php" class="btn btn-primary">
-                            <i class="bi bi-gear"></i> Settings
-                        </a>
-                    </div>
                 </div>
             </div>
 

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -7,6 +7,7 @@ $pdo = get_pdo();
 
 $success = false;
 $test_result = null;
+$active_tab = $_POST['active_tab'] ?? 'general';
 
 // Fetch upload statuses
 $statuses = $pdo->query('SELECT id, name, color FROM upload_statuses ORDER BY id')->fetchAll(PDO::FETCH_ASSOC);
@@ -83,7 +84,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $statuses = $pdo->query('SELECT id, name, color FROM upload_statuses ORDER BY id')->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    if (isset($_POST['test_groundhogg'])) {
+    if (isset($_POST['delete_chats'])) {
+        $pdo->exec('DELETE FROM store_messages WHERE store_id IS NOT NULL');
+        $active_tab = 'reset';
+    } elseif (isset($_POST['delete_broadcasts'])) {
+        $pdo->exec('DELETE FROM store_messages WHERE store_id IS NULL');
+        $active_tab = 'reset';
+    } elseif (isset($_POST['delete_uploads'])) {
+        $pdo->exec('DELETE FROM uploads');
+        $active_tab = 'reset';
+    } elseif (isset($_POST['delete_store_users'])) {
+        $pdo->exec('DELETE FROM store_users');
+        $active_tab = 'reset';
+    } elseif (isset($_POST['delete_stores'])) {
+        $pdo->exec('DELETE FROM stores');
+        $active_tab = 'reset';
+    } elseif (isset($_POST['test_groundhogg'])) {
         [$ok, $msg] = test_groundhogg_connection();
         $test_result = [$ok, $msg];
     }
@@ -137,20 +153,23 @@ include __DIR__.'/header.php';
     <form method="post" enctype="multipart/form-data">
         <ul class="nav nav-tabs" id="settingsTabs" role="tablist">
             <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="general-tab" data-bs-toggle="tab" data-bs-target="#general" type="button" role="tab">General</button>
+                <button class="nav-link<?php if($active_tab==='general') echo ' active'; ?>" id="general-tab" data-bs-toggle="tab" data-bs-target="#general" type="button" role="tab">General</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="dripley-tab" data-bs-toggle="tab" data-bs-target="#dripley" type="button" role="tab">Dripley CRM</button>
+                <button class="nav-link<?php if($active_tab==='dripley') echo ' active'; ?>" id="dripley-tab" data-bs-toggle="tab" data-bs-target="#dripley" type="button" role="tab">Dripley CRM</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="subjects-tab" data-bs-toggle="tab" data-bs-target="#subjects" type="button" role="tab">Email Subjects</button>
+                <button class="nav-link<?php if($active_tab==='subjects') echo ' active'; ?>" id="subjects-tab" data-bs-toggle="tab" data-bs-target="#subjects" type="button" role="tab">Email Subjects</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="statuses-tab" data-bs-toggle="tab" data-bs-target="#statuses" type="button" role="tab">Statuses</button>
+                <button class="nav-link<?php if($active_tab==='statuses') echo ' active'; ?>" id="statuses-tab" data-bs-toggle="tab" data-bs-target="#statuses" type="button" role="tab">Statuses</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link<?php if($active_tab==='reset') echo ' active'; ?>" id="reset-tab" data-bs-toggle="tab" data-bs-target="#reset" type="button" role="tab">Reset</button>
             </li>
         </ul>
         <div class="tab-content pt-3">
-            <div class="tab-pane fade show active" id="general" role="tabpanel" aria-labelledby="general-tab">
+            <div class="tab-pane fade<?php if($active_tab==='general') echo ' show active'; ?>" id="general" role="tabpanel" aria-labelledby="general-tab">
                 <div class="row">
                     <div class="col-lg-6">
                         <div class="card mb-4">
@@ -212,7 +231,7 @@ include __DIR__.'/header.php';
                 </div>
             </div>
 
-            <div class="tab-pane fade" id="dripley" role="tabpanel" aria-labelledby="dripley-tab">
+            <div class="tab-pane fade<?php if($active_tab==='dripley') echo ' show active'; ?>" id="dripley" role="tabpanel" aria-labelledby="dripley-tab">
                 <div class="card mb-4">
                     <div class="card-header">
                         <h5 class="mb-0">Dripley CRM Integration</h5>
@@ -256,7 +275,7 @@ include __DIR__.'/header.php';
                 </div>
             </div>
 
-            <div class="tab-pane fade" id="subjects" role="tabpanel" aria-labelledby="subjects-tab">
+            <div class="tab-pane fade<?php if($active_tab==='subjects') echo ' show active'; ?>" id="subjects" role="tabpanel" aria-labelledby="subjects-tab">
                 <div class="card mb-4">
                     <div class="card-header">
                         <h5 class="mb-0">Email Subject Lines - Uploads</h5>
@@ -304,7 +323,7 @@ include __DIR__.'/header.php';
                 </div>
             </div>
 
-            <div class="tab-pane fade" id="statuses" role="tabpanel" aria-labelledby="statuses-tab">
+            <div class="tab-pane fade<?php if($active_tab==='statuses') echo ' show active'; ?>" id="statuses" role="tabpanel" aria-labelledby="statuses-tab">
                 <div class="card mb-4">
                     <div class="card-header">
                         <h5 class="mb-0">Statuses</h5>
@@ -331,8 +350,31 @@ include __DIR__.'/header.php';
                     </div>
                 </div>
             </div>
-        </div>
 
+            <div class="tab-pane fade<?php if($active_tab==='reset') echo ' show active'; ?>" id="reset" role="tabpanel" aria-labelledby="reset-tab">
+                <div class="card mb-4">
+                    <div class="card-body">
+                        <p class="text-danger">These actions cannot be undone.</p>
+                        <div class="mb-2">
+                            <button class="btn btn-danger" type="submit" name="delete_chats" onclick="return confirm('Delete all chats?');">Delete All Chats</button>
+                        </div>
+                        <div class="mb-2">
+                            <button class="btn btn-danger" type="submit" name="delete_broadcasts" onclick="return confirm('Delete all broadcasts?');">Delete All Broadcasts</button>
+                        </div>
+                        <div class="mb-2">
+                            <button class="btn btn-danger" type="submit" name="delete_uploads" onclick="return confirm('Delete all uploads?');">Delete All Uploads</button>
+                        </div>
+                        <div class="mb-2">
+                            <button class="btn btn-danger" type="submit" name="delete_store_users" onclick="return confirm('Delete all store users?');">Delete All Store Users</button>
+                        </div>
+                        <div class="mb-2">
+                            <button class="btn btn-danger" type="submit" name="delete_stores" onclick="return confirm('Delete all stores?');">Delete All Stores</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <input type="hidden" name="active_tab" id="active_tab" value="<?php echo htmlspecialchars($active_tab); ?>">
         <button class="btn btn-primary" type="submit">Save Settings</button>
     </form>
 
@@ -350,10 +392,15 @@ include __DIR__.'/header.php';
             `;
             tbody.appendChild(row);
         });
-        document.addEventListener('click', function(e){
+       document.addEventListener('click', function(e){
             if(e.target.classList.contains('remove-status')){
                 e.target.closest('tr').remove();
             }
+        });
+        document.querySelectorAll('#settingsTabs button[data-bs-toggle="tab"]').forEach(btn=>{
+            btn.addEventListener('shown.bs.tab', e=>{
+                document.getElementById('active_tab').value = e.target.id.replace('-tab','');
+            });
         });
     </script>
 

--- a/public/messages.php
+++ b/public/messages.php
@@ -54,12 +54,12 @@ include __DIR__.'/header.php';
                 </small>
                 <span class="ms-1 reactions">
                     <?php if($msg['like_by_admin']||$msg['like_by_store']): ?>
-                        <i class="bi bi-hand-thumbs-up-fill text-danger" data-id="<?php echo $msg['id']; ?>" data-type="like"></i>
+                        <i class="bi bi-hand-thumbs-up-fill text-like" data-id="<?php echo $msg['id']; ?>" data-type="like"></i>
                     <?php else: ?>
                         <i class="bi bi-hand-thumbs-up" data-id="<?php echo $msg['id']; ?>" data-type="like"></i>
                     <?php endif; ?>
                     <?php if($msg['love_by_admin']||$msg['love_by_store']): ?>
-                        <i class="bi bi-heart-fill text-danger" data-id="<?php echo $msg['id']; ?>" data-type="love"></i>
+                        <i class="bi bi-heart-fill text-love" data-id="<?php echo $msg['id']; ?>" data-type="love"></i>
                     <?php else: ?>
                         <i class="bi bi-heart" data-id="<?php echo $msg['id']; ?>" data-type="love"></i>
                     <?php endif; ?>
@@ -99,10 +99,10 @@ function refreshMessages() {
                     ` <small class="text-muted ms-2">${m.created_at}${readIcon}</small>`+
                     ' <span class="ms-1 reactions">'+
                     (m.like_by_admin||m.like_by_store?
-                        `<i class="bi bi-hand-thumbs-up-fill text-danger" data-id="${m.id}" data-type="like"></i>`:
+                        `<i class="bi bi-hand-thumbs-up-fill text-like" data-id="${m.id}" data-type="like"></i>`:
                         `<i class="bi bi-hand-thumbs-up" data-id="${m.id}" data-type="like"></i>`)+' '+
                     (m.love_by_admin||m.love_by_store?
-                        `<i class="bi bi-heart-fill text-danger" data-id="${m.id}" data-type="love"></i>`:
+                        `<i class="bi bi-heart-fill text-love" data-id="${m.id}" data-type="love"></i>`:
                         `<i class="bi bi-heart" data-id="${m.id}" data-type="love"></i>`)+
                     '</span>';
                 wrap.appendChild(div);


### PR DESCRIPTION
## Summary
- add pastel styled dashboard cards and chat bubbles
- highlight broadcast messages in admin chat
- recolor reaction icons
- add Reset tab in settings for bulk deletion
- keep active settings tab after save
- adjust card order for quick actions

## Testing
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6875aac8c87c8326b6096757691fc208