### PR TITLE
Add status column and icon actions on admin dashboard

### DIFF
--- a/admin/header.php
+++ b/admin/header.php
@@ -12,6 +12,10 @@ $version = trim(file_get_contents(__DIR__.'/../VERSION'));
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+    <!-- Montserrat Font -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="inc/css/style.css?v=<?php echo $version; ?>">
 </head>
 <body>

--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -1,7 +1,7 @@
 /* Admin styles */
 .navbar-brand { font-weight: 600; }
 .navbar { background-color: #2c3e50 !important; }
-body { background-color: #f8f9fa; }
+body { background-color: #f8f9fa; font-family: 'Montserrat', sans-serif; }
 .card { border: none; }
 .btn-primary { background-color: #2c3e50; border-color: #2c3e50; }
 .btn-primary:hover { background-color: #1a252f; border-color: #1a252f; }

--- a/admin/login_header.php
+++ b/admin/login_header.php
@@ -6,6 +6,10 @@
     <title>Admin Login - MediaHub</title>
     <!-- Bootstrap CSS from CDN -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+    <!-- Montserrat Font -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="inc/css/style.css">
 </head>
 <body class="login-page">

--- a/public/header.php
+++ b/public/header.php
@@ -11,6 +11,10 @@ if (!isset($_SESSION)) { session_start(); }
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+    <!-- Montserrat Font -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="inc/css/style.css">
 </head>
 <body>

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -1,7 +1,7 @@
 /* Public styles */
 .navbar-brand { font-weight: 600; }
 .navbar { background-color: #2c3e50 !important; }
-body { background-color: #f8f9fa; }
+body { background-color: #f8f9fa; font-family: 'Montserrat', sans-serif; }
 .card { border: none; }
 .btn-primary { background-color: #2c3e50; border-color: #2c3e50; }
 .btn-primary:hover { background-color: #1a252f; border-color: #1a252f; }


### PR DESCRIPTION
## Summary
- show upload statuses in admin dashboard recent uploads
- shorten recent upload filenames
- use icon buttons for actions on dashboard tables
- embed Montserrat font sitewide

## Testing
- `php -l admin/index.php`
- `php -l admin/header.php`
- `php -l admin/login_header.php`
- `php -l public/header.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6875b1509a388326975810c0e67602a3