### PR TITLE
Update dashboard styling

### DIFF
--- a/admin/chat.php
+++ b/admin/chat.php
@@ -123,7 +123,7 @@ include __DIR__.'/header.php';
 <form method="post" id="chatForm" class="input-group align-items-end">
     <textarea name="message" class="form-control" rows="2" placeholder="Type message" required></textarea>
     <button type="button" id="emojiBtn" class="btn btn-light border"><i class="bi bi-emoji-smile"></i></button>
-    <button class="btn btn-primary" type="submit">Send</button>
+    <button class="btn btn-send" type="submit">Send</button>
     <input type="hidden" name="ajax" value="1">
     <input type="hidden" name="parent_id" id="parent_id" value="">
 </form>

--- a/admin/conversation.php
+++ b/admin/conversation.php
@@ -79,7 +79,7 @@ include __DIR__.'/header.php';
 <form method="post" id="convForm" class="input-group align-items-end mt-3">
     <textarea name="message" class="form-control" rows="2" required></textarea>
     <button type="button" id="emojiBtn" class="btn btn-light border"><i class="bi bi-emoji-smile"></i></button>
-    <button class="btn btn-primary" type="submit">Send</button>
+    <button class="btn btn-send" type="submit">Send</button>
     <input type="hidden" name="parent_id" id="parent_id" value="">
 </form>
 <script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1"></script>

--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -2,7 +2,8 @@
 .navbar-brand { font-weight: 600; }
 .navbar { background-color: #2c3e50 !important; }
 body { background-color: #f8f9fa; font-family: 'Montserrat', sans-serif; }
-.card { border: none; }
+.card { border: 1px solid #dee2e6; }
+.btn { border: 1px solid #dee2e6; }
 .btn-primary { background-color: #2c3e50; border-color: #2c3e50; }
 .btn-primary:hover { background-color: #1a252f; border-color: #1a252f; }
 .btn-outline-primary { color: #2c3e50; border-color: #2c3e50; }
@@ -58,5 +59,19 @@ a:hover { color: #1a252f; }
 .text-love { color: #FDE8E6 !important; }
 #messages .bubble.broadcast { background:#FDE8E6; }
 .bg-dashboard { background-color: #18bc9c !important; color: #fff !important; }
-.btn-dashboard { background-color: #18bc9c; border-color: #18bc9c; color: #fff; }
-.btn-dashboard:hover { background-color: #17a689; border-color: #17a689; color: #fff; }
+.btn-dashboard { background-color: #6c757d; border-color: #6c757d; color: #fff; }
+.btn-dashboard:hover { background-color: #5a6268; border-color: #545b62; color: #fff; }
+
+table th, table td {
+    vertical-align: middle !important;
+}
+
+/* Dashboard widget colors */
+.bg-stat-stores { background-color: #E8F0FE !important; }
+.bg-stat-uploads { background-color: #E6FAF1 !important; }
+.bg-stat-articles { background-color: #FDE8E6 !important; }
+.bg-stat-messages { background-color: #FEF7E1 !important; }
+.bg-stat-users { background-color: #FFF1E6 !important; }
+
+.btn-send { background-color: #18bc9c; border-color: #18bc9c; color: #fff; }
+.btn-send:hover { background-color: #17a689; border-color: #17a689; color: #fff; }

--- a/admin/index.php
+++ b/admin/index.php
@@ -182,7 +182,7 @@ include __DIR__.'/header.php';
     <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 row-cols-xl-5 g-3 mb-4">
         <div class="col">
             <a href="stores.php" class="text-decoration-none">
-                <div class="card bg-dashboard clickable-card">
+                <div class="card bg-stat-stores clickable-card">
                     <div class="card-body">
                         <h5 class="card-title">
                             <i class="bi bi-shop"></i> Total Stores
@@ -194,7 +194,7 @@ include __DIR__.'/header.php';
         </div>
         <div class="col">
             <a href="uploads.php" class="text-decoration-none">
-                <div class="card bg-dashboard clickable-card">
+                <div class="card bg-stat-uploads clickable-card">
                     <div class="card-body">
                         <h5 class="card-title">
                             <i class="bi bi-cloud-upload"></i> Total Uploads
@@ -206,7 +206,7 @@ include __DIR__.'/header.php';
         </div>
         <div class="col">
             <a href="articles.php" class="text-decoration-none">
-                <div class="card bg-dashboard clickable-card">
+                <div class="card bg-stat-articles clickable-card">
                     <div class="card-body">
                         <h5 class="card-title">
                             <i class="bi bi-file-text"></i> Articles
@@ -223,7 +223,7 @@ include __DIR__.'/header.php';
         </div>
         <div class="col">
             <a href="messages.php" class="text-decoration-none">
-                <div class="card bg-dashboard clickable-card">
+                <div class="card bg-stat-messages clickable-card">
                     <div class="card-body">
                         <h5 class="card-title">
                             <i class="bi bi-chat-dots"></i> Active Messages
@@ -235,7 +235,7 @@ include __DIR__.'/header.php';
         </div>
         <div class="col">
             <a href="stores.php" class="text-decoration-none">
-                <div class="card bg-dashboard clickable-card">
+                <div class="card bg-stat-users clickable-card">
                     <div class="card-body">
                         <h5 class="card-title">
                             <i class="bi bi-people"></i> Store Users
@@ -262,8 +262,8 @@ include __DIR__.'/header.php';
                             <table class="table table-sm">
                                 <thead>
                                 <tr>
-                                    <th class="preview-col-sm">Preview</th>
-                                    <th>Time</th>
+                                    <th class="preview-col-sm"></th>
+                                    <th><i class="bi bi-calendar"></i></th>
                                     <th>Store</th>
                                     <th>File</th>
                                     <th>Status</th>
@@ -449,7 +449,7 @@ include __DIR__.'/header.php';
                         <div class="mb-2">
                             <textarea name="quick_message" class="form-control" rows="3" placeholder="Message" required></textarea>
                         </div>
-                        <button class="btn btn-primary w-100" type="submit">Send</button>
+                        <button class="btn btn-send w-100" type="submit">Send</button>
                     </form>
                 </div>
             </div>

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -2,7 +2,8 @@
 .navbar-brand { font-weight: 600; }
 .navbar { background-color: #2c3e50 !important; }
 body { background-color: #f8f9fa; font-family: 'Montserrat', sans-serif; }
-.card { border: none; }
+.card { border: 1px solid #dee2e6; }
+.btn { border: 1px solid #dee2e6; }
 .btn-primary { background-color: #2c3e50; border-color: #2c3e50; }
 .btn-primary:hover { background-color: #1a252f; border-color: #1a252f; }
 .btn-outline-primary { color: #2c3e50; border-color: #2c3e50; }
@@ -37,3 +38,10 @@ body { background-color: #f8f9fa; font-family: 'Montserrat', sans-serif; }
 .article-status { font-size: 0.875rem; font-weight: 500; }
 .article-card { transition: all 0.3s ease; }
 .article-card:hover { transform: translateY(-2px); box-shadow: 0 4px 8px rgba(0,0,0,0.1); }
+
+table th, table td {
+    vertical-align: middle !important;
+}
+
+.btn-send { background-color: #18bc9c; border-color: #18bc9c; color: #fff; }
+.btn-send:hover { background-color: #17a689; border-color: #17a689; color: #fff; }

--- a/public/index.php
+++ b/public/index.php
@@ -512,7 +512,7 @@ include __DIR__.'/header.php';
                     </div>
                     <form method="post" action="send_message.php" id="quickChatForm" class="input-group mt-3">
                         <input type="text" name="message" class="form-control" placeholder="Reply..." required>
-                        <button class="btn btn-primary" type="submit">Send</button>
+                        <button class="btn btn-send" type="submit">Send</button>
                         <input type="hidden" name="ajax" value="1">
                         <input type="hidden" name="parent_id" id="parent_id" value="">
                     </form>

--- a/public/messages.php
+++ b/public/messages.php
@@ -71,7 +71,7 @@ include __DIR__.'/header.php';
 <form method="post" action="send_message.php" id="msgForm" class="input-group align-items-end">
     <textarea name="message" class="form-control" rows="2" placeholder="Type message" required></textarea>
     <button type="button" id="emojiBtn" class="btn btn-light border"><i class="bi bi-emoji-smile"></i></button>
-    <button type="submit" class="btn btn-primary">Send</button>
+    <button type="submit" class="btn btn-send">Send</button>
     <input type="hidden" name="ajax" value="1">
     <input type="hidden" name="parent_id" id="parent_id" value="">
 </form>


### PR DESCRIPTION
## Summary
- color-code dashboard widgets with pastel tones
- style quick action buttons in gray
- use green `btn-send` for all send buttons
- center table cell content and tweak recent uploads header
- add light borders around cards and buttons

## Testing
- `php -l admin/index.php`
- `php -l admin/chat.php`
- `php -l admin/conversation.php`
- `php -l public/index.php`
- `php -l public/messages.php`

------
https://chatgpt.com/codex/tasks/task_e_6875b4df12f48326a09a780325a6dc2b