### PR TITLE
Fix duplicate status insertion

### DIFF
--- a/update_database.php
+++ b/update_database.php
@@ -251,18 +251,26 @@ try {
     echo "• status_id column might already exist\n";
 }
 
-// Insert default statuses
+// Insert default statuses if not already present
 $defaultStatuses = [
     ['Reviewed', '#198754'],
     ['Pending Submission', '#ffc107'],
     ['Scheduled', '#0dcaf0']
 ];
 foreach ($defaultStatuses as $st) {
+    list($name, $color) = $st;
     try {
-        $stmt = $pdo->prepare("INSERT INTO upload_statuses (name, color) VALUES (?, ?) ON DUPLICATE KEY UPDATE color=VALUES(color)");
-        $stmt->execute($st);
+        $check = $pdo->prepare('SELECT COUNT(*) FROM upload_statuses WHERE name = ?');
+        $check->execute([$name]);
+        if (!$check->fetchColumn()) {
+            $stmt = $pdo->prepare('INSERT INTO upload_statuses (name, color) VALUES (?, ?)');
+            $stmt->execute([$name, $color]);
+            echo "✓ Added upload status $name\n";
+        } else {
+            echo "• Upload status already exists: $name\n";
+        }
     } catch (PDOException $e) {
-        // ignore
+        echo "✗ Error adding status $name: " . $e->getMessage() . "\n";
     }
 }
 


### PR DESCRIPTION
## Summary
- prevent default statuses from duplicating in `update_database.php`

## Testing
- `php -l update_database.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6875c2a1df8c8326819b3621a5bb1546