### PR TITLE
Add chat attachments and reply feature

### DIFF
--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -21,7 +21,7 @@ a:hover { color: #1a252f; }
 .navbar-logo { height: 35px; width: auto; }
 #adminUserInfo a { color: #fff; }
 #notifyCount { display: none; top:-10px; }
-#messages { max-height: 400px; overflow-y: auto; }
+#messages { height: 70vh; overflow-y: auto; }
 #messages .mine { text-align: right; }
 #messages .bubble { display:inline-block; padding:6px 12px; border-radius:12px; margin-bottom:4px; max-width:70%; }
 #messages .mine .bubble { background:#E6FAF1; }
@@ -55,8 +55,8 @@ a:hover { color: #1a252f; }
 .bg-pastel-mint { background-color: #E6FAF1 !important; }
 .bg-pastel-peach { background-color: #FFF1E6 !important; }
 .bg-pastel-pink { background-color: #FDE8E6 !important; }
-.text-like { color: #E8F0FE !important; }
-.text-love { color: #FDE8E6 !important; }
+.text-like { color: #0d6efd !important; }
+.text-love { color: #dc3545 !important; }
 #messages .bubble.broadcast { background:#FDE8E6; }
 .bg-dashboard { background-color: #18bc9c !important; color: #fff !important; }
 .btn-dashboard { background-color: #6c757d; border-color: #6c757d; color: #fff; }
@@ -75,3 +75,8 @@ table th, table td {
 
 .btn-send { background-color: #18bc9c; border-color: #18bc9c; color: #fff; }
 .btn-send:hover { background-color: #17a689; border-color: #17a689; color: #fff; }
+.chat-form textarea { height: 38px; resize: none; }
+#messages .bubble small { color: #999; }
+.reply-preview { font-size: 0.8rem; color: #666; border-left: 2px solid #ccc; padding-left:4px; margin-bottom:4px; }
+.reply-link { display:none; margin-left:4px; cursor:pointer; color:#0d6efd; font-size:0.8rem; }
+.bubble-container:hover .reply-link { display:inline-block; }

--- a/chat_upload.php
+++ b/chat_upload.php
@@ -1,0 +1,51 @@
+<?php
+require_once __DIR__.'/lib/db.php';
+require_once __DIR__.'/lib/helpers.php';
+require_once __DIR__.'/lib/auth.php';
+require_once __DIR__.'/lib/drive.php';
+
+ensure_session();
+$pdo = get_pdo();
+
+$isAdmin = isset($_SESSION['user_id']);
+$store_id = 0;
+if ($isAdmin) {
+    require_login();
+    $store_id = intval($_POST['store_id'] ?? 0);
+} else {
+    $store_id = intval($_SESSION['store_id'] ?? 0);
+}
+if ($store_id <= 0 || empty($_FILES['file']['tmp_name'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid request']);
+    exit;
+}
+
+$parent_id = intval($_POST['parent_id'] ?? 0) ?: null;
+$tmp = $_FILES['file']['tmp_name'];
+$orig = $_FILES['file']['name'];
+$size = $_FILES['file']['size'];
+$finfo = finfo_open(FILEINFO_MIME_TYPE);
+$mime = finfo_file($finfo, $tmp);
+finfo_close($finfo);
+
+try {
+    $folderId = get_or_create_store_folder($store_id);
+    $driveId = drive_upload($tmp, $mime, $orig, $folderId);
+    $ins = $pdo->prepare('INSERT INTO uploads (store_id, filename, created_at, ip, mime, size, drive_id) VALUES (?, ?, NOW(), ?, ?, ?, ?)');
+    $ins->execute([$store_id, $orig, $_SERVER['REMOTE_ADDR'] ?? '', $mime, $size, $driveId]);
+    $upload_id = $pdo->lastInsertId();
+
+    $sender = $isAdmin ? 'admin' : 'store';
+    $read_admin = $isAdmin ? 1 : 0;
+    $read_store = $isAdmin ? 0 : 1;
+    $msg = sanitize_message($_POST['message'] ?? $orig);
+    $stmt = $pdo->prepare('INSERT INTO store_messages (store_id, sender, message, parent_id, upload_id, created_at, read_by_admin, read_by_store) VALUES (?, ?, ?, ?, ?, NOW(), ?, ?)');
+    $stmt->execute([$store_id, $sender, $msg, $parent_id, $upload_id, $read_admin, $read_store]);
+
+    echo json_encode(['success' => true]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -45,3 +45,10 @@ table th, table td {
 
 .btn-send { background-color: #18bc9c; border-color: #18bc9c; color: #fff; }
 .btn-send:hover { background-color: #17a689; border-color: #17a689; color: #fff; }
+.chat-form textarea { height: 38px; resize: none; }
+#messages .bubble small { color: #999; }
+.text-like { color: #0d6efd !important; }
+.text-love { color: #dc3545 !important; }
+.reply-preview { font-size: 0.8rem; color: #666; border-left: 2px solid #ccc; padding-left:4px; margin-bottom:4px; }
+.reply-link { display:none; margin-left:4px; cursor:pointer; color:#0d6efd; font-size:0.8rem; }
+.bubble-container:hover .reply-link { display:inline-block; }


### PR DESCRIPTION
## Summary
- enable dynamic chat area height and show attachments
- color liked/hearted icons dark blue/red and lighten timestamps
- add reply-to features and file uploads for chats

## Testing
- `php -l admin/chat.php`
- `php -l public/messages.php`
- `php -l chat_upload.php`
- `php -l admin/inc/css/style.css`
- `php -l public/inc/css/style.css`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6875c4e3c8fc8326b4ef7f4850fba212