### PR TITLE
Improve chat emoji and admin sync

### DIFF
--- a/admin/chat.php
+++ b/admin/chat.php
@@ -137,8 +137,11 @@ include __DIR__.'/header.php';
     <input type="hidden" name="ajax" value="1">
     <input type="hidden" name="parent_id" id="parent_id" value="">
 </form>
-<script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1"></script>
-<emoji-picker id="emojiPicker"></emoji-picker>
+<div id="emojiPicker"></div>
+<script src="../assets/js/emoji-picker.js"></script>
+<script>
+initEmojiPicker(document.querySelector('#chatForm textarea'), document.getElementById('emojiBtn'), document.getElementById('emojiPicker'));
+</script>
 <?php endif; ?>
 <script>
 const ADMIN_NAME = <?php echo json_encode($admin_name); ?>;
@@ -199,12 +202,12 @@ if(document.getElementById('chatForm')){
         if(document.getElementById('fileInput').files.length){
             fd.append('store_id',STORE_ID);
             fetch('../chat_upload.php',{method:'POST',body:fd})
-                .then(r=>r.json())
-                .then(()=>{formEl.reset(); document.getElementById('replyTo').style.display='none'; refreshMessages();});
+                .then(async r=>{try{return await r.json();}catch(e){return {error:'Upload failed'};}})
+                .then(res=>{if(res.success){formEl.reset(); document.getElementById('replyTo').style.display='none'; refreshMessages();}else{alert(res.error||'Upload failed');}});
         } else {
             fetch('chat.php?store_id=<?php echo $store_id; ?>',{method:'POST',body:fd})
-                .then(r=>r.json())
-                .then(()=>{formEl.reset(); document.getElementById('replyTo').style.display='none'; refreshMessages();});
+                .then(async r=>{try{return await r.json();}catch(e){return {error:'Send failed'};}})
+                .then(res=>{if(res.success){formEl.reset(); document.getElementById('replyTo').style.display='none'; refreshMessages();}else{alert(res.error||'Send failed');}});
         }
     });
     document.querySelector('#chatForm textarea').addEventListener('keydown',function(e){

--- a/admin/conversation.php
+++ b/admin/conversation.php
@@ -82,8 +82,11 @@ include __DIR__.'/header.php';
     <button class="btn btn-send" type="submit">Send</button>
     <input type="hidden" name="parent_id" id="parent_id" value="">
 </form>
-<script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1"></script>
-<emoji-picker id="emojiPicker"></emoji-picker>
+<div id="emojiPicker"></div>
+<script src="../assets/js/emoji-picker.js"></script>
+<script>
+initEmojiPicker(document.querySelector('#convForm textarea'), document.getElementById('emojiBtn'), document.getElementById('emojiPicker'));
+</script>
 <script>
 const ADMIN_NAME = <?php echo json_encode($admin_name); ?>;
 const STORE_CONTACT = <?php echo json_encode($store_contact); ?>;

--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -21,12 +21,13 @@ a:hover { color: #1a252f; }
 .navbar-logo { height: 35px; width: auto; }
 #adminUserInfo a { color: #fff; }
 #notifyCount { display: none; top:-10px; }
-#messages { height: 70vh; overflow-y: auto; }
+#messages { height: 65vh; overflow-y: auto; }
 #messages .mine { text-align: right; }
 #messages .bubble { display:inline-block; padding:6px 12px; border-radius:12px; margin-bottom:4px; max-width:70%; }
 #messages .mine .bubble { background:#E6FAF1; }
 #messages .theirs .bubble { background:#E8F0FE; }
-#emojiPicker { display:none; position:absolute; bottom:60px; right:20px; }
+#emojiPicker { display:none; position:absolute; bottom:60px; right:20px; background:#fff; border:1px solid #ccc; padding:4px; border-radius:4px; }
+.emoji-option{font-size:1.2rem; padding:2px; cursor:pointer;}
 .preview-col-sm { width: 60px; }
 .preview-img-sm { width: 50px; height: 50px; object-fit: cover; }
 .upload-card { height: 100%; transition: all 0.3s ease; border: 1px solid #c3c3c3; padding: 0.25rem; }

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -267,9 +267,10 @@ include __DIR__.'/header.php';
                             <input type="text" name="groundhogg_contact_tags" id="groundhogg_contact_tags" class="form-control" value="<?php echo htmlspecialchars($groundhogg_contact_tags); ?>">
                             <div class="form-text">Comma-separated tags applied to new contacts</div>
                         </div>
-                        <div class="d-flex gap-2">
+                        <div class="d-flex flex-wrap gap-2">
                             <button class="btn btn-secondary" type="submit" name="test_groundhogg">Test Connection</button>
-                            <a href="sync_groundhogg.php" class="btn btn-secondary">Sync Contacts</a>
+                            <a href="sync_groundhogg.php" class="btn btn-secondary">Sync Store Contacts</a>
+                            <a href="sync_admin_users.php" class="btn btn-secondary">Sync Admin Users</a>
                         </div>
                     </div>
                 </div>

--- a/admin/sync_admin_users.php
+++ b/admin/sync_admin_users.php
@@ -1,0 +1,55 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/auth.php';
+require_once __DIR__.'/../lib/groundhogg.php';
+require_login();
+$pdo = get_pdo();
+
+$results = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sync_all'])) {
+    $results = groundhogg_sync_admin_users();
+}
+
+$active = 'settings';
+include __DIR__.'/header.php';
+?>
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h4>Sync Admin Users with Groundhogg</h4>
+    <a href="settings.php" class="btn btn-sm btn-outline-secondary">Back to Settings</a>
+</div>
+<?php if (!empty($results)): ?>
+    <div class="card mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">Sync Results</h5>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-sm">
+                    <thead>
+                    <tr><th>Email</th><th>Status</th><th>Message</th></tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($results as $r): ?>
+                        <tr>
+                            <td><?php echo htmlspecialchars($r['email']); ?></td>
+                            <td><?php echo $r['success'] ? '<span class="badge bg-success">Success</span>' : '<span class="badge bg-danger">Failed</span>'; ?></td>
+                            <td><?php echo htmlspecialchars($r['message']); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+<?php endif; ?>
+<div class="card">
+    <div class="card-body">
+        <h5 class="card-title">Sync All Admin Users</h5>
+        <p class="card-text">This will sync all admin users with Groundhogg CRM.</p>
+        <form method="post">
+            <button type="submit" name="sync_all" class="btn btn-primary" onclick="return confirm('Sync all admin users with Groundhogg?');">Sync Admin Users</button>
+        </form>
+    </div>
+</div>
+<?php include __DIR__.'/footer.php'; ?>

--- a/assets/js/emoji-picker.js
+++ b/assets/js/emoji-picker.js
@@ -1,0 +1,18 @@
+window.initEmojiPicker = function(textarea, button, pickerEl){
+    const emojis = ['😀','😁','😂','🤣','😊','😎','😍','😘','😜','🤔','👍','👎','🎉','❤️','🔥','✨'];
+    pickerEl.innerHTML = '';
+    emojis.forEach(em=>{
+        const span=document.createElement('span');
+        span.textContent=em;
+        span.className='emoji-option';
+        span.addEventListener('click',()=>{
+            textarea.value += em;
+            pickerEl.style.display='none';
+            textarea.focus();
+        });
+        pickerEl.appendChild(span);
+    });
+    button.addEventListener('click',()=>{
+        pickerEl.style.display = pickerEl.style.display==='none' ? 'block' : 'none';
+    });
+};

--- a/lib/groundhogg.php
+++ b/lib/groundhogg.php
@@ -326,3 +326,27 @@ function groundhogg_sync_store_contacts(int $store_id): array {
 
     return [true, $results];
 }
+
+// Sync all admin users with Groundhogg
+function groundhogg_sync_admin_users(): array {
+    $pdo = get_pdo();
+    $users = $pdo->query('SELECT first_name, last_name, email FROM users ORDER BY id')->fetchAll(PDO::FETCH_ASSOC);
+    $results = [];
+    foreach ($users as $user) {
+        $contact = [
+            'email'       => $user['email'],
+            'first_name'  => $user['first_name'] ?? '',
+            'last_name'   => $user['last_name'] ?? '',
+            'company_name'=> 'Cosmick Media',
+            'user_role'   => 'Admin User',
+            'tags'        => groundhogg_get_default_tags()
+        ];
+        [$success, $message] = groundhogg_send_contact($contact);
+        $results[] = [
+            'email' => $user['email'],
+            'success' => $success,
+            'message' => $message
+        ];
+    }
+    return $results;
+}

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -19,12 +19,13 @@ body { background-color: #f8f9fa; font-family: 'Montserrat', sans-serif; }
 #latestChats .bubble { display: inline-block; padding: 6px 12px; border-radius: 12px; margin-bottom: 4px; max-width: 70%; }
 #latestChats .mine .bubble { background: #d1e7dd; }
 #latestChats .theirs .bubble { background: #e2e3e5; }
-#messages { height: 70vh; overflow-y: auto; margin-left: 0.5rem; margin-right: 0.5rem; }
+#messages { height: 65vh; overflow-y: auto; margin-left: 0.5rem; margin-right: 0.5rem; }
 #messages .mine { text-align: right; }
 #messages .bubble { display: inline-block; padding: 6px 12px; border-radius: 12px; margin-bottom: 4px; max-width: 70%; }
 #messages .mine .bubble { background: #d1e7dd; }
 #messages .theirs .bubble { background: #e2e3e5; }
-#emojiPicker { display: none; position: absolute; bottom: 60px; right: 20px; }
+#emojiPicker { display: none; position: absolute; bottom: 60px; right: 20px; background:#fff; border:1px solid #ccc; padding:4px; border-radius:4px; }
+.emoji-option { font-size: 1.2rem; padding:2px; cursor:pointer; }
 #reportFrame { width: 100%; border: 0; }
 .preview-col { width: 100px; }
 .preview-img { width: 80px; height: 80px; object-fit: cover; }

--- a/public/messages.php
+++ b/public/messages.php
@@ -85,8 +85,11 @@ include __DIR__.'/header.php';
     <input type="hidden" name="ajax" value="1">
     <input type="hidden" name="parent_id" id="parent_id" value="">
 </form>
-<script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@^1"></script>
-<emoji-picker id="emojiPicker"></emoji-picker>
+<div id="emojiPicker"></div>
+<script src="../assets/js/emoji-picker.js"></script>
+<script>
+initEmojiPicker(document.querySelector('#msgForm textarea'), document.getElementById('emojiBtn'), document.getElementById('emojiPicker'));
+</script>
 <script>
 const ADMIN_NAME = <?php echo json_encode($admin_name); ?>;
 const YOUR_NAME = <?php echo json_encode($your_name); ?>;
@@ -138,12 +141,12 @@ document.getElementById('msgForm').addEventListener('submit', function(e){
     if(document.getElementById('fileInput').files.length){
         fd.append('ajax','1');
         fetch('../chat_upload.php',{method:'POST',body:fd})
-            .then(r=>r.json())
-            .then(()=>{ this.reset(); document.getElementById('replyTo').style.display='none'; refreshMessages(); });
+            .then(async r=>{try{return await r.json();}catch(e){return {error:'Upload failed'};}})
+            .then(res=>{ if(res.success){ this.reset(); document.getElementById('replyTo').style.display='none'; refreshMessages(); } else { alert(res.error||'Upload failed'); } });
     }else{
         fetch('send_message.php', {method:'POST', body:fd})
-            .then(r=>r.json())
-            .then(()=>{ this.reset(); document.getElementById('replyTo').style.display='none'; refreshMessages(); });
+            .then(async r=>{try{return await r.json();}catch(e){return {error:'Send failed'};}})
+            .then(res=>{ if(res.success){ this.reset(); document.getElementById('replyTo').style.display='none'; refreshMessages(); } else { alert(res.error||'Send failed'); } });
     }
 });
 document.querySelector('#msgForm textarea').addEventListener('keydown', function(e){


### PR DESCRIPTION
## Summary
- tweak chat message area height and add local emoji picker
- handle file send errors gracefully
- allow syncing admin users to Dripley CRM

## Testing
- `php -l admin/chat.php`
- `php -l public/messages.php`
- `php -l admin/conversation.php`
- `php -l admin/sync_admin_users.php`
- `php -l lib/groundhogg.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6875c9fb80988326b72bbb831621f39d