### PR TITLE
Improve chat UX

### DIFF
--- a/admin/footer.php
+++ b/admin/footer.php
@@ -3,19 +3,22 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
 <script>
 function checkNotifications(){
-    fetch('/admin/notifications.php')
+    fetch('notifications.php')
         .then(r=>r.json())
         .then(d=>{
+            const wrap=document.getElementById('notifyWrap');
             const countEl=document.getElementById('notifyCount');
+            if(!wrap) return;
             if(d.count>0){
+                wrap.style.display='inline-block';
                 countEl.style.display='inline-block';
                 countEl.textContent=d.count;
             }else{
-                countEl.style.display='none';
+                wrap.style.display='none';
             }
         });
 }
-setInterval(checkNotifications,10000);
+setInterval(checkNotifications,5000);
 checkNotifications();
 </script>
 <?php $version = trim(file_get_contents(__DIR__.'/../VERSION')); ?>

--- a/admin/header.php
+++ b/admin/header.php
@@ -39,7 +39,7 @@ $version = trim(file_get_contents(__DIR__.'/../VERSION'));
             </ul>
             <div id="adminUserInfo" class="ms-auto text-end small text-white d-flex align-items-center">
                 <span class="me-2">Logged in as: <?php echo htmlspecialchars(trim(($_SESSION['first_name'] ?? '') . ' ' . ($_SESSION['last_name'] ?? ''))); ?></span>
-                <span class="position-relative me-2">
+                <span id="notifyWrap" class="position-relative me-2">
                     <i class="bi bi-bell" id="notifyBell"></i>
                     <span class="position-absolute start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount">0</span>
                 </span>

--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -79,5 +79,9 @@ table th, table td {
 .chat-form textarea { height: 38px; resize: none; }
 #messages .bubble small { color: #999; }
 .reply-preview { font-size: 0.8rem; color: #666; border-left: 2px solid #ccc; padding-left:4px; margin-bottom:4px; }
-.reply-link { display:none; margin-left:4px; cursor:pointer; color:#0d6efd; font-size:0.8rem; }
-.bubble-container:hover .reply-link { display:inline-block; }
+.bubble-container{position:relative;padding-bottom:18px;}
+.reply-link{display:none;position:absolute;bottom:0;right:0;color:#888;font-size:0.8rem;cursor:pointer;}
+.bubble-container:hover .reply-link{display:block;}
+.mention-box{position:absolute;background:#fff;border:1px solid #ccc;z-index:1000;max-height:150px;overflow-y:auto;padding:2px;display:none;}
+.mention-box div{padding:2px 4px;cursor:pointer;}
+.mention-box div:hover{background:#f0f0f0;}

--- a/chat_upload.php
+++ b/chat_upload.php
@@ -15,7 +15,7 @@ if ($isAdmin) {
 } else {
     $store_id = intval($_SESSION['store_id'] ?? 0);
 }
-if ($store_id <= 0 || empty($_FILES['file']['tmp_name'])) {
+if ($store_id <= 0 || !isset($_FILES['file']) || !is_uploaded_file($_FILES['file']['tmp_name'])) {
     http_response_code(400);
     echo json_encode(['error' => 'Invalid request']);
     exit;

--- a/public/footer.php
+++ b/public/footer.php
@@ -6,16 +6,19 @@ function checkNotifications(){
     fetch('notifications.php')
         .then(r=>r.json())
         .then(d=>{
-            const el=document.getElementById('notifyCount');
-            if(el){
-                if(d.count>0){
-                    el.style.display='inline-block';
-                    el.textContent=d.count;
-                }else{el.style.display='none';}
+            const wrap=document.getElementById('notifyWrap');
+            const count=document.getElementById('notifyCount');
+            if(!wrap) return;
+            if(d.count>0){
+                wrap.style.display='inline-block';
+                count.style.display='inline-block';
+                count.textContent=d.count;
+            }else{
+                wrap.style.display='none';
             }
         });
 }
-setInterval(checkNotifications,10000);
+setInterval(checkNotifications,5000);
 checkNotifications();
 </script>
 </body>

--- a/public/header.php
+++ b/public/header.php
@@ -37,10 +37,12 @@ if (!isset($_SESSION)) { session_start(); }
             </ul>
             <div id="publicUserInfo" class="ms-auto d-flex align-items-center navbar-text small text-white">
                 <span class="me-2">Logged in as: <?php echo htmlspecialchars(trim(($_SESSION['store_first_name'] ?? '') . ' ' . ($_SESSION['store_last_name'] ?? ''))); ?></span>
-                <a class="nav-link position-relative text-white me-2" href="messages.php">
-                    <i class="bi bi-bell"></i>
-                    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount">0</span>
-                </a>
+                <span id="notifyWrap" class="position-relative me-2">
+                    <a id="notifyBell" class="nav-link position-relative text-white p-0" href="messages.php">
+                        <i class="bi bi-bell"></i>
+                        <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" id="notifyCount">0</span>
+                    </a>
+                </span>
                 <a class="nav-link text-white" href="?logout=1"><i class="bi bi-box-arrow-right"></i></a>
             </div>
             <?php endif; ?>

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -51,5 +51,9 @@ table th, table td {
 .text-like { color: #0d6efd !important; }
 .text-love { color: #dc3545 !important; }
 .reply-preview { font-size: 0.8rem; color: #666; border-left: 2px solid #ccc; padding-left:4px; margin-bottom:4px; }
-.reply-link { display:none; margin-left:4px; cursor:pointer; color:#0d6efd; font-size:0.8rem; }
-.bubble-container:hover .reply-link { display:inline-block; }
+.bubble-container{position:relative;padding-bottom:18px;}
+.reply-link{display:none;position:absolute;bottom:0;right:0;color:#888;font-size:0.8rem;cursor:pointer;}
+.bubble-container:hover .reply-link{display:block;}
+.mention-box{position:absolute;background:#fff;border:1px solid #ccc;z-index:1000;max-height:150px;overflow-y:auto;padding:2px;display:none;}
+.mention-box div{padding:2px 4px;cursor:pointer;}
+.mention-box div:hover{background:#f0f0f0;}


### PR DESCRIPTION
## Summary
- refine reply link to stay fixed below each chat message
- show notification bell only when there are unread messages
- add simple @mention autocomplete
- handle file upload validation edge cases

## Testing
- `php -l admin/chat.php`
- `php -l admin/footer.php`
- `php -l admin/header.php`
- `php -l chat_upload.php`
- `php -l public/footer.php`
- `php -l public/header.php`
- `php -l public/messages.php`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875ce3f0964832698767846980ecd78