### PR TITLE
Improve chat UI and add sidebar toggle

### DIFF
--- a/admin/chat.php
+++ b/admin/chat.php
@@ -74,13 +74,13 @@ $active = 'chat';
 include __DIR__.'/header.php';
 ?>
 <div class="row">
-  <div class="col-lg-9 mb-3">
-    <h4>Chat - <?php echo htmlspecialchars($store_name); ?></h4>
+  <div class="col-lg-9 mb-3" id="chatMain">
+    <h4 class="d-none">Chat - <?php echo htmlspecialchars($store_name); ?></h4>
     <div id="unreadAlert" class="alert alert-warning alert-dismissible fade show" role="alert" style="display:none;">
         You have <span id="totalUnread">0</span> new message(s) from <span id="unreadStores">0</span> stores.
         <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
     </div>
-    <form method="get" class="mb-3" id="storeSelectForm">
+    <form method="get" class="mb-3 d-none" id="storeSelectForm">
         <label class="form-label">Select Store</label>
         <select name="store_id" class="form-select" id="storeSelect" onchange="document.getElementById('storeSelectForm').submit();">
             <option value="0" disabled<?php if($store_id===0) echo ' selected'; ?>>Please select store</option>
@@ -181,9 +181,12 @@ mentionBox.addEventListener('click',e=>{
 </script>
 <?php endif; ?>
   </div>
-  <div class="col-lg-3">
+  <div class="col-lg-3" id="chatSidebar">
     <div class="card h-100">
-      <div class="card-header"><h5 class="mb-0">Stores</h5></div>
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <h5 class="mb-0">Store Chats</h5>
+        <button type="button" id="sidebarToggle" class="btn btn-sm btn-light"><i class="bi bi-chevron-right"></i></button>
+      </div>
       <div class="card-body p-0">
         <ul class="list-group list-group-flush" id="storeList">
           <?php foreach($stores as $s): ?>
@@ -197,6 +200,7 @@ mentionBox.addEventListener('click',e=>{
     </div>
   </div>
 </div>
+<div id="sidebarTab" class="sidebar-tab"><i class="bi bi-chevron-left"></i></div>
 <script>
 const ADMIN_NAME = <?php echo json_encode($admin_name); ?>;
 const STORE_CONTACT = <?php echo json_encode($store_contact ?? ''); ?>;
@@ -341,5 +345,18 @@ document.querySelectorAll('.store-link').forEach(l=>{
         document.getElementById('storeSelectForm').submit();
     });
 });
+const sidebarToggle=document.getElementById('sidebarToggle');
+const sidebarTab=document.getElementById('sidebarTab');
+function hideSidebar(){
+    document.body.classList.add('sidebar-hidden');
+    localStorage.setItem('chatSidebarHidden','1');
+}
+function showSidebar(){
+    document.body.classList.remove('sidebar-hidden');
+    localStorage.setItem('chatSidebarHidden','0');
+}
+if(sidebarToggle){sidebarToggle.addEventListener('click',hideSidebar);} 
+if(sidebarTab){sidebarTab.addEventListener('click',showSidebar);} 
+if(localStorage.getItem('chatSidebarHidden')==='1'){hideSidebar();}
 </script>
 <?php include __DIR__.'/footer.php'; ?>

--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -23,7 +23,7 @@ a:hover { color: #1a252f; }
 #notifyCount { display: none; top:-10px; }
 #messages { height: 65vh; overflow-y: auto; }
 #messages .mine { text-align: right; }
-#messages .bubble { display:inline-block; padding:6px 12px; border-radius:12px; margin-bottom:4px; max-width:70%; }
+#messages .bubble { display:inline-block; padding:6px 12px; border-radius:12px; margin-bottom:4px; max-width:85%; }
 #messages .mine .bubble { background:#E6FAF1; }
 #messages .theirs .bubble { background:#E8F0FE; }
 .chat-form { position: relative; }
@@ -88,3 +88,21 @@ table th, table td {
 .mention-box div:hover{background:#f0f0f0;}
 .sidebar-locked .offcanvas-end{transform:none!important;visibility:visible!important;}
 .sidebar-locked .offcanvas-backdrop{display:none;}
+
+/* Chat sidebar toggle */
+#sidebarTab{
+    position:fixed;
+    top:50%;
+    right:0;
+    transform:translateY(-50%);
+    background:#2c3e50;
+    color:#fff;
+    padding:4px 6px;
+    border-radius:4px 0 0 4px;
+    cursor:pointer;
+    display:none;
+    z-index:1040;
+}
+.sidebar-hidden #sidebarTab{display:block;}
+.sidebar-hidden #chatSidebar{display:none;}
+.sidebar-hidden #chatMain{flex:0 0 100%;max-width:100%;}

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -182,16 +182,16 @@ include __DIR__.'/header.php';
                     <div class="form-text">For notifications specific to this store</div>
                 </div>
                 <div class="col-md-6">
+                    <label for="phone" class="form-label">Phone</label>
+                    <input type="text" name="phone" id="phone" class="form-control">
+                </div>
+                <div class="col-md-6">
                     <label for="first_name" class="form-label">First Name</label>
                     <input type="text" name="first_name" id="first_name" class="form-control">
                 </div>
                 <div class="col-md-6">
                     <label for="last_name" class="form-label">Last Name</label>
                     <input type="text" name="last_name" id="last_name" class="form-control">
-                </div>
-                <div class="col-md-6">
-                    <label for="phone" class="form-label">Phone</label>
-                    <input type="text" name="phone" id="phone" class="form-control">
                 </div>
                 <div class="col-md-6">
                     <label for="address" class="form-label">Address</label>

--- a/assets/js/emoji-picker.js
+++ b/assets/js/emoji-picker.js
@@ -12,7 +12,13 @@ window.initEmojiPicker = function(textarea, button, pickerEl){
         });
         pickerEl.appendChild(span);
     });
-    button.addEventListener('click',()=>{
+    button.addEventListener('click',e=>{
+        e.stopPropagation();
         pickerEl.style.display = pickerEl.style.display==='none' ? 'block' : 'none';
+    });
+    document.addEventListener('click',e=>{
+        if(!pickerEl.contains(e.target) && e.target!==button){
+            pickerEl.style.display='none';
+        }
     });
 };

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -16,12 +16,12 @@ body { background-color: #f8f9fa; font-family: 'Montserrat', sans-serif; }
 #cameraInput { display: none; }
 #latestChats { max-height: 300px; overflow-y: auto; }
 #latestChats .mine { text-align: right; }
-#latestChats .bubble { display: inline-block; padding: 6px 12px; border-radius: 12px; margin-bottom: 4px; max-width: 70%; }
+#latestChats .bubble { display: inline-block; padding: 6px 12px; border-radius: 12px; margin-bottom: 4px; max-width: 85%; }
 #latestChats .mine .bubble { background: #d1e7dd; }
 #latestChats .theirs .bubble { background: #e2e3e5; }
 #messages { height: 65vh; overflow-y: auto; margin-left: 0.5rem; margin-right: 0.5rem; }
 #messages .mine { text-align: right; }
-#messages .bubble { display: inline-block; padding: 6px 12px; border-radius: 12px; margin-bottom: 4px; max-width: 70%; }
+#messages .bubble { display: inline-block; padding: 6px 12px; border-radius: 12px; margin-bottom: 4px; max-width: 85%; }
 #messages .mine .bubble { background: #d1e7dd; }
 #messages .theirs .bubble { background: #e2e3e5; }
 .chat-form { position: relative; }


### PR DESCRIPTION
## Summary
- reorder phone field so first/last name share a row
- widen chat bubbles across public and admin styles
- hide chat title and store dropdown on chat page
- rename sidebar heading and add hide/show toggle with persistent state
- allow clicking outside emoji picker to hide it

## Testing
- `php -l admin/stores.php`
- `php -l admin/chat.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6875dc1b599c83269c392ea8070ae59d