### PR TITLE
Add extended contact fields for Groundhogg

### DIFF
--- a/admin/edit_store_user.php
+++ b/admin/edit_store_user.php
@@ -1,6 +1,8 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
+require_once __DIR__.'/../lib/groundhogg.php';
+require_once __DIR__.'/../lib/helpers.php';
 require_login();
 $pdo = get_pdo();
 
@@ -26,12 +28,39 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_user'])) {
     if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
         $errors[] = 'Valid email is required';
     } else {
-        $stmt = $pdo->prepare('UPDATE store_users SET email=?, first_name=?, last_name=? WHERE id=? AND store_id=?');
-        $stmt->execute([$email, $first ?: null, $last ?: null, $id, $store_id]);
+        $mobile = format_mobile_number($_POST['mobile_phone'] ?? '');
+        $optin = $_POST['opt_in_status'] ?? 'confirmed';
+        $stmt = $pdo->prepare('UPDATE store_users SET email=?, first_name=?, last_name=?, mobile_phone=?, opt_in_status=? WHERE id=? AND store_id=?');
+        $stmt->execute([$email, $first ?: null, $last ?: null, $mobile ?: null, $optin, $id, $store_id]);
         $success = true;
         $stmt = $pdo->prepare('SELECT * FROM store_users WHERE id=? AND store_id=?');
         $stmt->execute([$id, $store_id]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        // fetch store for location data
+        $storeStmt = $pdo->prepare('SELECT * FROM stores WHERE id=?');
+        $storeStmt->execute([$store_id]);
+        $store = $storeStmt->fetch(PDO::FETCH_ASSOC);
+
+        $contact = [
+            'email'        => $email,
+            'first_name'   => $first,
+            'last_name'    => $last,
+            'mobile_phone' => $mobile,
+            'address'      => $store['address'] ?? '',
+            'city'         => $store['city'] ?? '',
+            'state'        => $store['state'] ?? '',
+            'zip'          => $store['zip_code'] ?? '',
+            'country'      => $store['country'] ?? '',
+            'company_name' => $store['name'] ?? '',
+            'user_role'    => 'Store Admin',
+            'lead_source'  => 'mediahub',
+            'opt_in_status'=> $optin,
+            'tags'         => groundhogg_get_default_tags(),
+            'store_id'     => (int)$store_id
+        ];
+
+        groundhogg_send_contact($contact);
     }
 }
 
@@ -57,17 +86,30 @@ include __DIR__.'/header.php';
 <div class="card">
     <div class="card-body">
         <form method="post" class="row g-3">
-            <div class="col-md-6">
+            <div class="col-md-4">
                 <label for="first_name" class="form-label">First Name</label>
                 <input type="text" name="first_name" id="first_name" class="form-control" value="<?php echo htmlspecialchars($user['first_name']); ?>">
             </div>
-            <div class="col-md-6">
+            <div class="col-md-4">
                 <label for="last_name" class="form-label">Last Name</label>
                 <input type="text" name="last_name" id="last_name" class="form-control" value="<?php echo htmlspecialchars($user['last_name']); ?>">
             </div>
-            <div class="col-md-6">
+            <div class="col-md-4">
                 <label for="email" class="form-label">Email</label>
                 <input type="email" name="email" id="email" class="form-control" required value="<?php echo htmlspecialchars($user['email']); ?>">
+            </div>
+            <div class="col-md-4">
+                <label for="mobile_phone" class="form-label">Mobile Phone</label>
+                <input type="text" name="mobile_phone" id="mobile_phone" class="form-control" value="<?php echo htmlspecialchars($user['mobile_phone']); ?>">
+            </div>
+            <div class="col-md-4">
+                <label for="opt_in_status" class="form-label">Opt-in Status</label>
+                <select name="opt_in_status" id="opt_in_status" class="form-select">
+                    <?php $statuses=['unconfirmed','confirmed','unsubscribed','subscribed_weekly','subscribed_monthly','bounced','spam','complained','blocked'];
+                    foreach($statuses as $status): ?>
+                        <option value="<?php echo $status; ?>"<?php echo $user['opt_in_status']==$status?' selected':''; ?>><?php echo ucfirst(str_replace('_',' ', $status)); ?></option>
+                    <?php endforeach; ?>
+                </select>
             </div>
             <div class="col-12">
                 <button class="btn btn-primary" name="save_user" type="submit">Save Changes</button>

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -2,6 +2,7 @@
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
 require_once __DIR__.'/../lib/groundhogg.php';
+require_once __DIR__.'/../lib/helpers.php';
 require_login();
 $pdo = get_pdo();
 
@@ -16,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $errors[] = 'PIN already exists';
         } else {
-            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_token, first_name, last_name, phone, address, marketing_report_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_token, first_name, last_name, phone, address, city, state, zip_code, country, marketing_report_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
             $stmt->execute([
                 $_POST['name'],
                 $_POST['pin'],
@@ -25,8 +26,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $_POST['hootsuite_token'],
                 $_POST['first_name'] ?? null,
                 $_POST['last_name'] ?? null,
-                $_POST['phone'] ?? null,
+                format_mobile_number($_POST['phone'] ?? ''),
                 $_POST['address'] ?? null,
+                $_POST['city'] ?? null,
+                $_POST['state'] ?? null,
+                $_POST['zip_code'] ?? null,
+                $_POST['country'] ?? null,
                 $_POST['marketing_report_url'] ?? null
             ]);
             $storeId = $pdo->lastInsertId();
@@ -38,9 +43,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'email'        => $_POST['email'],
                     'first_name'   => $_POST['first_name'] ?? '',
                     'last_name'    => $_POST['last_name'] ?? '',
-                    'phone'        => $_POST['phone'] ?? '',
+                    'mobile_phone' => format_mobile_number($_POST['phone'] ?? ''),
+                    'address'      => $_POST['address'] ?? '',
+                    'city'         => $_POST['city'] ?? '',
+                    'state'        => $_POST['state'] ?? '',
+                    'zip'          => $_POST['zip_code'] ?? '',
+                    'country'      => $_POST['country'] ?? '',
                     'company_name' => $_POST['name'] ?? '',
                     'user_role'    => 'Store Admin',
+                    'lead_source'  => 'mediahub',
+                    'opt_in_status'=> 'confirmed',
                     'tags'         => groundhogg_get_default_tags(),
                     'store_id'     => (int)$storeId
                 ];
@@ -196,6 +208,22 @@ include __DIR__.'/header.php';
                 <div class="col-md-6">
                     <label for="address" class="form-label">Address</label>
                     <input type="text" name="address" id="address" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="city" class="form-label">City</label>
+                    <input type="text" name="city" id="city" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="state" class="form-label">State</label>
+                    <input type="text" name="state" id="state" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="zip_code" class="form-label">Zip Code</label>
+                    <input type="text" name="zip_code" id="zip_code" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="country" class="form-label">Country</label>
+                    <input type="text" name="country" id="country" class="form-control">
                 </div>
                 <div class="col-md-6">
                     <label for="folder" class="form-label">Drive Folder ID</label>

--- a/admin/users.php
+++ b/admin/users.php
@@ -16,21 +16,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $first = trim($_POST['first_name'] ?? '');
         $last = trim($_POST['last_name'] ?? '');
         $email = trim($_POST['email'] ?? '');
+        $mobile = format_mobile_number($_POST['mobile_phone'] ?? '');
+        $optin = $_POST['opt_in_status'] ?? 'confirmed';
         if ($username === '' || $password === '' || $email === '') {
             $errors[] = 'Username, password and email are required';
         } else {
             $hash = password_hash($password, PASSWORD_DEFAULT);
             try {
-                $stmt = $pdo->prepare('INSERT INTO users (username, password, first_name, last_name, email) VALUES (?, ?, ?, ?, ?)');
-                $stmt->execute([$username, $hash, $first ?: null, $last ?: null, $email]);
+                $stmt = $pdo->prepare('INSERT INTO users (username, password, first_name, last_name, email, mobile_phone, opt_in_status) VALUES (?, ?, ?, ?, ?, ?, ?)');
+                $stmt->execute([$username, $hash, $first ?: null, $last ?: null, $email, $mobile ?: null, $optin]);
                 $success[] = 'User added';
 
                 $contact = [
                     'email'       => $email,
                     'first_name'  => $first,
                     'last_name'   => $last,
+                    'mobile_phone'=> $mobile,
+                    'address'     => '1147 Jacobsburg Rd.',
+                    'city'        => 'Wind Gap',
+                    'state'       => 'Pennsylvania',
+                    'zip'         => '18091',
+                    'country'     => 'United States',
                     'user_role'   => 'Admin User',
                     'company_name'=> 'Cosmick Media',
+                    'lead_source' => 'cosmick-employee',
+                    'opt_in_status'=> $optin,
                     'tags'        => groundhogg_get_default_tags()
                 ];
                 [$ghSuccess, $ghMessage] = groundhogg_send_contact($contact);
@@ -112,25 +122,43 @@ include __DIR__.'/header.php';
         </div>
         <div class="card-body">
             <form method="post" class="row g-3">
-                <div class="col-md-6">
+                <div class="col-md-4">
                     <label for="username" class="form-label">Username</label>
                     <input type="text" name="username" id="username" class="form-control" required>
                 </div>
-                <div class="col-md-6">
+                <div class="col-md-4">
                     <label for="password" class="form-label">Password</label>
                     <input type="password" name="password" id="password" class="form-control" required>
                 </div>
-                <div class="col-md-6">
+                <div class="col-md-4">
                     <label for="first_name" class="form-label">First Name</label>
                     <input type="text" name="first_name" id="first_name" class="form-control">
                 </div>
-                <div class="col-md-6">
+                <div class="col-md-4">
                     <label for="last_name" class="form-label">Last Name</label>
                     <input type="text" name="last_name" id="last_name" class="form-control">
                 </div>
-                <div class="col-md-6">
+                <div class="col-md-4">
                     <label for="email" class="form-label">Email</label>
                     <input type="email" name="email" id="email" class="form-control" required>
+                </div>
+                <div class="col-md-4">
+                    <label for="mobile_phone" class="form-label">Mobile Phone</label>
+                    <input type="text" name="mobile_phone" id="mobile_phone" class="form-control">
+                </div>
+                <div class="col-md-4">
+                    <label for="opt_in_status" class="form-label">Opt-in Status</label>
+                    <select name="opt_in_status" id="opt_in_status" class="form-select">
+                        <option value="confirmed" selected>Confirmed</option>
+                        <option value="unconfirmed">Unconfirmed</option>
+                        <option value="unsubscribed">Unsubscribed</option>
+                        <option value="subscribed_weekly">Subscribed Weekly</option>
+                        <option value="subscribed_monthly">Subscribed Monthly</option>
+                        <option value="bounced">Bounced</option>
+                        <option value="spam">Spam</option>
+                        <option value="complained">Complained</option>
+                        <option value="blocked">Blocked</option>
+                    </select>
                 </div>
                 <div class="col-12">
                     <button class="btn btn-primary" name="add" type="submit">Add User</button>

--- a/cmuploader.sql
+++ b/cmuploader.sql
@@ -220,6 +220,10 @@ CREATE TABLE `stores` (
   `last_name` varchar(100) DEFAULT NULL,
   `phone` varchar(50) DEFAULT NULL,
   `address` varchar(255) DEFAULT NULL,
+  `city` varchar(100) DEFAULT NULL,
+  `state` varchar(100) DEFAULT NULL,
+  `zip_code` varchar(20) DEFAULT NULL,
+  `country` varchar(100) DEFAULT NULL,
   `marketing_report_url` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
@@ -227,11 +231,11 @@ CREATE TABLE `stores` (
 -- Dumping data for table `stores`
 --
 
-INSERT INTO `stores` (`id`, `name`, `pin`, `admin_email`, `drive_folder`, `hootsuite_token`, `first_name`, `last_name`, `phone`, `address`, `marketing_report_url`) VALUES
-(1, 'test', '1111', 'test@none.com', '', NULL, NULL, NULL, NULL, NULL, NULL),
-(2, 'testing', '1234', 'test@none.com', '16FMaL4Lv0V6_ZVxBQRpg-3GaUyfeu0G3', NULL, NULL, NULL, NULL, NULL, NULL),
-(3, 'Petland Cosmick', '2547', 'cosmicktechnologies@gmail.com', '1srY5v90SaXNgWsl56K_e9F0YaSN43Hc-', '', 'Carley', 'Kuehner', '', '1147 Jacobsburg Road, Wind Gap, PA 18091', NULL),
-(4, 'Petland Phoenix', '2345', 'kim@cosmickmedia.com', '1VvZT3W4_ADzo1nRXPg98n8wOROIov9lC', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO `stores` (`id`, `name`, `pin`, `admin_email`, `drive_folder`, `hootsuite_token`, `first_name`, `last_name`, `phone`, `address`, `city`, `state`, `zip_code`, `country`, `marketing_report_url`) VALUES
+(1, 'test', '1111', 'test@none.com', '', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+(2, 'testing', '1234', 'test@none.com', '16FMaL4Lv0V6_ZVxBQRpg-3GaUyfeu0G3', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+(3, 'Petland Cosmick', '2547', 'cosmicktechnologies@gmail.com', '1srY5v90SaXNgWsl56K_e9F0YaSN43Hc-', '', 'Carley', 'Kuehner', '', '1147 Jacobsburg Road', 'Wind Gap', 'PA', '18091', 'United States', NULL),
+(4, 'Petland Phoenix', '2345', 'kim@cosmickmedia.com', '1VvZT3W4_ADzo1nRXPg98n8wOROIov9lC', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 -- --------------------------------------------------------
 
@@ -304,6 +308,8 @@ CREATE TABLE `store_users` (
   `email` varchar(255) NOT NULL,
   `first_name` varchar(100) DEFAULT NULL,
   `last_name` varchar(100) DEFAULT NULL,
+  `mobile_phone` varchar(50) DEFAULT NULL,
+  `opt_in_status` enum('unconfirmed','confirmed','unsubscribed','subscribed_weekly','subscribed_monthly','bounced','spam','complained','blocked') DEFAULT 'confirmed',
   `created_at` timestamp NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
@@ -311,14 +317,14 @@ CREATE TABLE `store_users` (
 -- Dumping data for table `store_users`
 --
 
-INSERT INTO `store_users` (`id`, `store_id`, `email`, `first_name`, `last_name`, `created_at`) VALUES
-(1, 3, 'ckuehner@cosmickmedia.com', 'Tatiana', 'Marchenko', '2025-07-13 20:38:47'),
-(3, 4, 'kaykaykuehner@gmail.com', 'Kayley', 'Kuehner', '2025-07-14 02:58:12'),
-(4, 3, 'crystal@cosmickmedia.com', 'Crystal', 'Jones', '2025-07-14 15:21:35'),
-(5, 3, 'kim@cosmickmedia.com', 'Kim', 'Frassinelli', '2025-07-14 15:25:08'),
-(6, 4, 'kim@cosmickmedia.com', 'Kim', 'Frassinelli', '2025-07-14 18:23:46'),
-(7, 3, 'jim@yalley.com', 'Jim', 'Talley', '2025-07-14 23:50:35'),
-(9, 3, 'sdfdf@none.com', 'Cosmick Media Inc.', 'sdfsfdsdf', '2025-07-14 23:55:09');
+INSERT INTO `store_users` (`id`, `store_id`, `email`, `first_name`, `last_name`, `mobile_phone`, `opt_in_status`, `created_at`) VALUES
+(1, 3, 'ckuehner@cosmickmedia.com', 'Tatiana', 'Marchenko', NULL, 'confirmed', '2025-07-13 20:38:47'),
+(3, 4, 'kaykaykuehner@gmail.com', 'Kayley', 'Kuehner', NULL, 'confirmed', '2025-07-14 02:58:12'),
+(4, 3, 'crystal@cosmickmedia.com', 'Crystal', 'Jones', NULL, 'confirmed', '2025-07-14 15:21:35'),
+(5, 3, 'kim@cosmickmedia.com', 'Kim', 'Frassinelli', NULL, 'confirmed', '2025-07-14 15:25:08'),
+(6, 4, 'kim@cosmickmedia.com', 'Kim', 'Frassinelli', NULL, 'confirmed', '2025-07-14 18:23:46'),
+(7, 3, 'jim@yalley.com', 'Jim', 'Talley', NULL, 'confirmed', '2025-07-14 23:50:35'),
+(9, 3, 'sdfdf@none.com', 'Cosmick Media Inc.', 'sdfsfdsdf', NULL, 'confirmed', '2025-07-14 23:55:09');
 
 -- --------------------------------------------------------
 
@@ -427,6 +433,8 @@ CREATE TABLE `users` (
   `first_name` varchar(100) DEFAULT NULL,
   `last_name` varchar(100) DEFAULT NULL,
   `email` varchar(255) DEFAULT NULL,
+  `mobile_phone` varchar(50) DEFAULT NULL,
+  `opt_in_status` enum('unconfirmed','confirmed','unsubscribed','subscribed_weekly','subscribed_monthly','bounced','spam','complained','blocked') DEFAULT 'confirmed',
   `created_at` timestamp NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
@@ -434,12 +442,12 @@ CREATE TABLE `users` (
 -- Dumping data for table `users`
 --
 
-INSERT INTO `users` (`id`, `username`, `password`, `first_name`, `last_name`, `email`, `created_at`) VALUES
-(1, 'admin', '$2y$10$aIKmnAZxd/D5WdCHFMmto.tMsL3os10L8yUC5W4XMSdeKee/8vGpi', 'Carley', 'Kuehner', 'carley@cosmickmedia.com', '2025-07-13 20:14:56'),
-(14, 'Cassandra', '$2y$10$eLQoBqTNE7dBqF0ViWYBlOXKHZvMPrLPjuF8cr0wyneOnTS6rW62y', 'Cassandra', 'Dayoub', 'cassandra@cosmickmedia.com', '2025-07-14 15:20:05'),
-(15, 'Kim', '$2y$10$AB5EDYNdWqv/Xjvrj1RPCO.Cig7KH1Os.HvQYH2yvgNW62Q5nl0Qy', 'Kim', 'Frassinelli', 'kim@cosmickmedia.com', '2025-07-14 15:21:17'),
-(16, 'JBirgl', '$2y$10$cw3QNqgGumA3tEfCc9EP0OT77dy210tqNg/EhNY/KP5kALV4iEqza', 'Jennifer', 'Birgl', 'jennifer@cosmickmedia.com', '2025-07-14 15:21:38'),
-(18, 'Crystal Jones', '$2y$10$JqU85tn1smnru0itTPDK/OyPQ16V9JqYzcysxk6OtImVjOm/h6yZC', 'Crystal', 'Jones', 'crystal@cosmickmedia.com', '2025-07-14 16:16:55');
+INSERT INTO `users` (`id`, `username`, `password`, `first_name`, `last_name`, `email`, `mobile_phone`, `opt_in_status`, `created_at`) VALUES
+(1, 'admin', '$2y$10$aIKmnAZxd/D5WdCHFMmto.tMsL3os10L8yUC5W4XMSdeKee/8vGpi', 'Carley', 'Kuehner', 'carley@cosmickmedia.com', NULL, 'confirmed', '2025-07-13 20:14:56'),
+(14, 'Cassandra', '$2y$10$eLQoBqTNE7dBqF0ViWYBlOXKHZvMPrLPjuF8cr0wyneOnTS6rW62y', 'Cassandra', 'Dayoub', 'cassandra@cosmickmedia.com', NULL, 'confirmed', '2025-07-14 15:20:05'),
+(15, 'Kim', '$2y$10$AB5EDYNdWqv/Xjvrj1RPCO.Cig7KH1Os.HvQYH2yvgNW62Q5nl0Qy', 'Kim', 'Frassinelli', 'kim@cosmickmedia.com', NULL, 'confirmed', '2025-07-14 15:21:17'),
+(16, 'JBirgl', '$2y$10$cw3QNqgGumA3tEfCc9EP0OT77dy210tqNg/EhNY/KP5kALV4iEqza', 'Jennifer', 'Birgl', 'jennifer@cosmickmedia.com', NULL, 'confirmed', '2025-07-14 15:21:38'),
+(18, 'Crystal Jones', '$2y$10$JqU85tn1smnru0itTPDK/OyPQ16V9JqYzcysxk6OtImVjOm/h6yZC', 'Crystal', 'Jones', 'crystal@cosmickmedia.com', NULL, 'confirmed', '2025-07-14 16:16:55');
 
 --
 -- Indexes for dumped tables

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -36,3 +36,18 @@ function shorten_filename(string $filename, int $baseLength = 8): string {
 
     return substr($base, 0, $baseLength) . '...' . $ext;
 }
+
+function format_mobile_number(string $number): string {
+    $digits = preg_replace('/\D+/', '', $number);
+    if ($digits === '') {
+        return '';
+    }
+    if (strlen($digits) === 10) {
+        $digits = '1' . $digits;
+    }
+    if ($digits[0] !== '1') {
+        // assume already has country code
+        return '+' . $digits;
+    }
+    return '+' . $digits;
+}

--- a/update_database.php
+++ b/update_database.php
@@ -107,6 +107,20 @@ try {
     echo "• last_name column might already exist\n";
 }
 
+try {
+    $pdo->exec("ALTER TABLE store_users ADD COLUMN mobile_phone VARCHAR(50) AFTER last_name");
+    echo "✓ Added mobile_phone column to store_users table\n";
+} catch (PDOException $e) {
+    echo "• mobile_phone column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE store_users ADD COLUMN opt_in_status ENUM('unconfirmed','confirmed','unsubscribed','subscribed_weekly','subscribed_monthly','bounced','spam','complained','blocked') DEFAULT 'confirmed' AFTER mobile_phone");
+    echo "✓ Added opt_in_status column to store_users table\n";
+} catch (PDOException $e) {
+    echo "• opt_in_status column might already exist\n";
+}
+
 // Add sender column to store_messages table
 try {
     $pdo->exec("ALTER TABLE store_messages ADD COLUMN sender ENUM('admin','store') DEFAULT 'admin' AFTER store_id");
@@ -197,6 +211,34 @@ try {
 }
 
 try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN city VARCHAR(100) AFTER address");
+    echo "✓ Added city column to stores table\n";
+} catch (PDOException $e) {
+    echo "• city column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN state VARCHAR(100) AFTER city");
+    echo "✓ Added state column to stores table\n";
+} catch (PDOException $e) {
+    echo "• state column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN zip_code VARCHAR(20) AFTER state");
+    echo "✓ Added zip_code column to stores table\n";
+} catch (PDOException $e) {
+    echo "• zip_code column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN country VARCHAR(100) AFTER zip_code");
+    echo "✓ Added country column to stores table\n";
+} catch (PDOException $e) {
+    echo "• country column might already exist\n";
+}
+
+try {
     $pdo->exec("ALTER TABLE stores ADD COLUMN marketing_report_url VARCHAR(255) AFTER address");
     echo "✓ Added marketing_report_url column to stores table\n";
 } catch (PDOException $e) {
@@ -227,6 +269,20 @@ try {
     echo "✓ Added email column to users table\n";
 } catch (PDOException $e) {
     echo "• email column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE users ADD COLUMN mobile_phone VARCHAR(50) AFTER email");
+    echo "✓ Added mobile_phone column to users table\n";
+} catch (PDOException $e) {
+    echo "• mobile_phone column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE users ADD COLUMN opt_in_status ENUM('unconfirmed','confirmed','unsubscribed','subscribed_weekly','subscribed_monthly','bounced','spam','complained','blocked') DEFAULT 'confirmed' AFTER mobile_phone");
+    echo "✓ Added opt_in_status column to users table\n";
+} catch (PDOException $e) {
+    echo "• opt_in_status column might already exist\n";
 }
 
 // Create upload_statuses table


### PR DESCRIPTION
## Summary
- add location and phone helpers
- update store, store user, and admin user forms to collect mobile phone and opt-in status
- persist new fields to the database
- pass location, phone, lead source and opt-in status to Groundhogg
- update database update script and schema

## Testing
- `php -l admin/edit_store.php`
- `php -l admin/edit_store_user.php`
- `php -l admin/edit_user.php`
- `php -l admin/stores.php`
- `php -l admin/users.php`
- `php -l lib/groundhogg.php`
- `php -l lib/helpers.php`
- `php -l update_database.php`

------
https://chatgpt.com/codex/tasks/task_e_6876a4f2a4208326a2816672e151eeea