### PR TITLE
Fix Groundhogg admin contact sync

### DIFF
--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -129,9 +129,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $errors[] = 'Invalid email';
         }
     } elseif (isset($_POST['delete_user'])) {
+        $stmt = $pdo->prepare('SELECT email FROM store_users WHERE id=? AND store_id=?');
+        $stmt->execute([$_POST['user_id'], $id]);
+        $email = $stmt->fetchColumn();
+
         $stmt = $pdo->prepare('DELETE FROM store_users WHERE id=? AND store_id=?');
         $stmt->execute([$_POST['user_id'], $id]);
         $success[] = 'User removed';
+
+        if ($email) {
+            [$delSuccess, $delMsg] = groundhogg_delete_contact($email);
+            if (!$delSuccess) {
+                $errors[] = 'Groundhogg delete failed: ' . $delMsg;
+            }
+        }
+
         // Refresh user list
         $userStmt->execute([$id]);
         $store_users = $userStmt->fetchAll(PDO::FETCH_ASSOC);

--- a/admin/edit_user.php
+++ b/admin/edit_user.php
@@ -45,7 +45,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_user'])) {
             'mobile_phone'=> $mobile,
             'address'     => '1147 Jacobsburg Rd.',
             'city'        => 'Wind Gap',
-            'state'       => 'Pennsylvania',
+            'state'       => 'PA',
             'zip'         => '18091',
             'country'     => 'US',
             'user_role'   => 'Admin User',

--- a/admin/users.php
+++ b/admin/users.php
@@ -34,7 +34,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'mobile_phone'=> $mobile,
                     'address'     => '1147 Jacobsburg Rd.',
                     'city'        => 'Wind Gap',
-                    'state'       => 'Pennsylvania',
+                    'state'       => 'PA',
                     'zip'         => '18091',
                     'country'     => 'US',
                     'user_role'   => 'Admin User',
@@ -54,9 +54,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
     } elseif (isset($_POST['delete']) && isset($_POST['id'])) {
+        $stmt = $pdo->prepare('SELECT email FROM users WHERE id=?');
+        $stmt->execute([$_POST['id']]);
+        $email = $stmt->fetchColumn();
+
         $stmt = $pdo->prepare('DELETE FROM users WHERE id=?');
         $stmt->execute([$_POST['id']]);
         $success[] = 'User deleted';
+
+        if ($email) {
+            [$delSuccess, $delMsg] = groundhogg_delete_contact($email);
+            if (!$delSuccess) {
+                $errors[] = 'Groundhogg delete failed: ' . $delMsg;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- send Groundhogg address fields using correct meta keys
- add `groundhogg_delete_contact()` helper
- remove contacts from Groundhogg when deleting stores, store users or admin users
- store static admin address with state `PA`

## Testing
- `php -l lib/groundhogg.php`
- `php -l admin/users.php`
- `php -l admin/edit_store.php`
- `php -l admin/edit_user.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6876ace36b40832680af353a06f38ad3