### PR TITLE
Update Groundhogg sync and add location settings

### DIFF
--- a/admin/edit_user.php
+++ b/admin/edit_user.php
@@ -38,16 +38,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save_user'])) {
             $stmt = $pdo->prepare('UPDATE users SET username=?, first_name=?, last_name=?, email=?, mobile_phone=?, opt_in_status=? WHERE id=?');
             $stmt->execute([$username, $first ?: null, $last ?: null, $email, $mobile ?: null, $optin, $id]);
         }
+        $location = groundhogg_get_location();
         $contact = [
             'email'       => $email,
             'first_name'  => $first,
             'last_name'   => $last,
             'mobile_phone'=> $mobile,
-            'address'     => '1147 Jacobsburg Rd.',
-            'city'        => 'Wind Gap',
-            'state'       => 'PA',
-            'zip'         => '18091',
-            'country'     => 'US',
+            'address'     => $location['address'],
+            'city'        => $location['city'],
+            'state'       => $location['state'],
+            'zip'         => $location['zip'],
+            'country'     => $location['country'],
             'user_role'   => 'Admin User',
             'company_name'=> 'Cosmick Media',
             'lead_source' => 'cosmick-employee',

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -51,7 +51,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'groundhogg_token'        => trim($_POST['groundhogg_token'] ?? ''),
         'groundhogg_secret_key'   => trim($_POST['groundhogg_secret_key'] ?? ''),
         'groundhogg_debug'        => isset($_POST['groundhogg_debug']) ? '1' : '0',
-        'groundhogg_contact_tags' => trim($_POST['groundhogg_contact_tags'] ?? '')
+        'groundhogg_contact_tags' => trim($_POST['groundhogg_contact_tags'] ?? ''),
+        'company_address'         => trim($_POST['company_address'] ?? ''),
+        'company_city'            => trim($_POST['company_city'] ?? ''),
+        'company_state'           => trim($_POST['company_state'] ?? ''),
+        'company_zip'             => trim($_POST['company_zip'] ?? ''),
+        'company_country'         => trim($_POST['company_country'] ?? '')
     ];
 
     foreach ($settings as $name => $value) {
@@ -118,6 +123,11 @@ $admin_article_notification_subject = get_setting('admin_article_notification_su
 $store_article_notification_subject = get_setting('store_article_notification_subject') ?: 'Article Submission Confirmation - Cosmick Media';
 $article_approval_subject = get_setting('article_approval_subject') ?: 'Article Status Update - Cosmick Media';
 $max_article_length = get_setting('max_article_length') ?: '50000';
+$company_address = get_setting('company_address') ?: '';
+$company_city = get_setting('company_city') ?: '';
+$company_state = get_setting('company_state') ?: '';
+$company_zip = get_setting('company_zip') ?: '';
+$company_country = get_setting('company_country') ?: '';
 $groundhogg_site_url = get_setting('groundhogg_site_url');
 $groundhogg_username = get_setting('groundhogg_username');
 $groundhogg_public_key = get_setting('groundhogg_public_key');
@@ -225,6 +235,34 @@ include __DIR__.'/header.php';
                                     <input type="email" name="email_from_address" id="email_from_address" class="form-control" value="<?php echo htmlspecialchars($email_from_address); ?>">
                                     <div class="form-text">Email address used for sending</div>
                                 </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card mb-4">
+                        <div class="card-header">
+                            <h5 class="mb-0">Location Information</h5>
+                        </div>
+                        <div class="card-body">
+                            <div class="mb-3">
+                                <label for="company_address" class="form-label">Address</label>
+                                <input type="text" name="company_address" id="company_address" class="form-control" placeholder="123 Main St." value="<?php echo htmlspecialchars($company_address); ?>">
+                            </div>
+                            <div class="mb-3">
+                                <label for="company_city" class="form-label">City</label>
+                                <input type="text" name="company_city" id="company_city" class="form-control" placeholder="Wind Gap" value="<?php echo htmlspecialchars($company_city); ?>">
+                            </div>
+                            <div class="mb-3">
+                                <label for="company_state" class="form-label">State</label>
+                                <input type="text" name="company_state" id="company_state" class="form-control" placeholder="PA" value="<?php echo htmlspecialchars($company_state); ?>">
+                            </div>
+                            <div class="mb-3">
+                                <label for="company_zip" class="form-label">Zip Code</label>
+                                <input type="text" name="company_zip" id="company_zip" class="form-control" placeholder="18091" value="<?php echo htmlspecialchars($company_zip); ?>">
+                            </div>
+                            <div class="mb-3">
+                                <label for="company_country" class="form-label">Country</label>
+                                <input type="text" name="company_country" id="company_country" class="form-control" placeholder="US" value="<?php echo htmlspecialchars($company_country); ?>">
                             </div>
                         </div>
                     </div>

--- a/admin/users.php
+++ b/admin/users.php
@@ -27,16 +27,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $stmt->execute([$username, $hash, $first ?: null, $last ?: null, $email, $mobile ?: null, $optin]);
                 $success[] = 'User added';
 
+                $location = groundhogg_get_location();
                 $contact = [
                     'email'       => $email,
                     'first_name'  => $first,
                     'last_name'   => $last,
                     'mobile_phone'=> $mobile,
-                    'address'     => '1147 Jacobsburg Rd.',
-                    'city'        => 'Wind Gap',
-                    'state'       => 'PA',
-                    'zip'         => '18091',
-                    'country'     => 'US',
+                    'address'     => $location['address'],
+                    'city'        => $location['city'],
+                    'state'       => $location['state'],
+                    'zip'         => $location['zip'],
+                    'country'     => $location['country'],
                     'user_role'   => 'Admin User',
                     'company_name'=> 'Cosmick Media',
                     'lead_source' => 'cosmick-employee',

--- a/lib/groundhogg.php
+++ b/lib/groundhogg.php
@@ -31,6 +31,22 @@ function groundhogg_get_settings(): array {
     ];
 }
 
+function groundhogg_get_location(): array {
+    $pdo = get_pdo();
+    $stmt = $pdo->prepare(
+        "SELECT name, value FROM settings WHERE name IN ('company_address','company_city','company_state','company_zip','company_country')"
+    );
+    $stmt->execute();
+    $rows = $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
+    return [
+        'address' => $rows['company_address'] ?? '',
+        'city'    => $rows['company_city'] ?? '',
+        'state'   => $rows['company_state'] ?? '',
+        'zip'     => $rows['company_zip'] ?? '',
+        'country' => $rows['company_country'] ?? ''
+    ];
+}
+
 function groundhogg_debug_enabled(): bool {
     $settings = groundhogg_get_settings();
     return $settings['debug'] === '1';
@@ -434,6 +450,7 @@ function groundhogg_sync_store_contacts(int $store_id): array {
 function groundhogg_sync_admin_users(): array {
     $pdo = get_pdo();
     $users = $pdo->query('SELECT first_name, last_name, email, mobile_phone, opt_in_status FROM users ORDER BY id')->fetchAll(PDO::FETCH_ASSOC);
+    $location = groundhogg_get_location();
     $results = [];
     foreach ($users as $user) {
         $contact = [
@@ -441,11 +458,11 @@ function groundhogg_sync_admin_users(): array {
             'first_name'  => $user['first_name'] ?? '',
             'last_name'   => $user['last_name'] ?? '',
             'mobile_phone'=> format_mobile_number($user['mobile_phone'] ?? ''),
-            'address'     => '1147 Jacobsburg Rd.',
-            'city'        => 'Wind Gap',
-            'state'       => 'PA',
-            'zip'         => '18091',
-            'country'     => 'US',
+            'address'     => $location['address'],
+            'city'        => $location['city'],
+            'state'       => $location['state'],
+            'zip'         => $location['zip'],
+            'country'     => $location['country'],
             'company_name'=> 'Cosmick Media',
             'user_role'   => 'Admin User',
             'lead_source' => 'cosmick-employee',

--- a/setup.php
+++ b/setup.php
@@ -294,7 +294,12 @@ $defaultSettings = [
     'groundhogg_token' => '',
     'groundhogg_secret_key' => '',
     // Default tags applied to contacts created in Groundhogg
-    'groundhogg_contact_tags' => 'media-hub, store-onboarding'
+    'groundhogg_contact_tags' => 'media-hub, store-onboarding',
+    'company_address' => '',
+    'company_city' => '',
+    'company_state' => '',
+    'company_zip' => '',
+    'company_country' => ''
 ];
 
 foreach ($defaultSettings as $name => $value) {

--- a/update_database.php
+++ b/update_database.php
@@ -53,7 +53,12 @@ $defaultSettings = [
     'store_notification_subject' => 'Content Submission Confirmation - Cosmick Media',
     'store_message_subject' => 'New message from Cosmick Media',
     // Default tags for Groundhogg contacts
-    'groundhogg_contact_tags' => 'media-hub, store-onboarding'
+    'groundhogg_contact_tags' => 'media-hub, store-onboarding',
+    'company_address' => '',
+    'company_city' => '',
+    'company_state' => '',
+    'company_zip' => '',
+    'company_country' => ''
 ];
 
 foreach ($defaultSettings as $name => $value) {


### PR DESCRIPTION
## Summary
- add company location settings
- display location fields in admin settings
- fetch location data when syncing admin users to Groundhogg
- use location info for admin user sync/update

## Testing
- `php -l admin/settings.php`
- `php -l update_database.php`
- `php -l setup.php`
- `php -l lib/groundhogg.php`
- `php -l admin/users.php`
- `php -l admin/edit_user.php`


------
https://chatgpt.com/codex/tasks/task_e_6876b07472748326a261a3503d0a6a2f