### PR TITLE
Add calendar import from Google Sheets

### DIFF
--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -31,13 +31,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $errors[] = 'PIN already exists';
         } else {
-            $update = $pdo->prepare('UPDATE stores SET name=?, pin=?, admin_email=?, drive_folder=?, hootsuite_token=?, first_name=?, last_name=?, phone=?, address=?, city=?, state=?, zip_code=?, country=?, marketing_report_url=? WHERE id=?');
+            $update = $pdo->prepare('UPDATE stores SET name=?, pin=?, admin_email=?, drive_folder=?, hootsuite_token=?, hootsuite_campaign_tag=?, first_name=?, last_name=?, phone=?, address=?, city=?, state=?, zip_code=?, country=?, marketing_report_url=? WHERE id=?');
             $update->execute([
                 $_POST['name'],
                 $_POST['pin'],
                 $_POST['email'],
                 $_POST['folder'],
                 $_POST['hootsuite_token'],
+                $_POST['hootsuite_campaign_tag'] ?? null,
                 $_POST['first_name'] ?? null,
                 $_POST['last_name'] ?? null,
                 format_mobile_number($_POST['phone'] ?? ''),
@@ -233,6 +234,10 @@ include __DIR__.'/header.php';
             <div class="col-md-6">
                 <label for="hootsuite_token" class="form-label">Hootsuite Access Token</label>
                 <input type="text" name="hootsuite_token" id="hootsuite_token" class="form-control" value="<?php echo htmlspecialchars($store['hootsuite_token']); ?>">
+            </div>
+            <div class="col-md-6">
+                <label for="hootsuite_campaign_tag" class="form-label">Hootsuite Campaign Tag</label>
+                <input type="text" name="hootsuite_campaign_tag" id="hootsuite_campaign_tag" class="form-control" value="<?php echo htmlspecialchars($store['hootsuite_campaign_tag']); ?>">
             </div>
         </div>
     </div>

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -56,7 +56,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'company_city'            => trim($_POST['company_city'] ?? ''),
         'company_state'           => trim($_POST['company_state'] ?? ''),
         'company_zip'             => trim($_POST['company_zip'] ?? ''),
-        'company_country'         => trim($_POST['company_country'] ?? '')
+        'company_country'         => trim($_POST['company_country'] ?? ''),
+        'calendar_sheet_url'      => trim($_POST['calendar_sheet_url'] ?? ''),
+        'calendar_update_interval'=> trim($_POST['calendar_update_interval'] ?? '24')
     ];
 
     foreach ($settings as $name => $value) {
@@ -107,6 +109,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif (isset($_POST['test_groundhogg'])) {
         [$ok, $msg] = test_groundhogg_connection();
         $test_result = [$ok, $msg];
+    } elseif (isset($_POST['force_calendar_update'])) {
+        require_once __DIR__.'/../lib/calendar.php';
+        [$ok, $msg] = calendar_update(true);
+        $test_result = [$ok, $msg];
     }
     $success = true;
 }
@@ -128,6 +134,8 @@ $company_city = get_setting('company_city') ?: '';
 $company_state = get_setting('company_state') ?: '';
 $company_zip = get_setting('company_zip') ?: '';
 $company_country = get_setting('company_country') ?: '';
+$calendar_sheet_url = get_setting('calendar_sheet_url') ?: '';
+$calendar_update_interval = get_setting('calendar_update_interval') ?: '24';
 $groundhogg_site_url = get_setting('groundhogg_site_url');
 $groundhogg_username = get_setting('groundhogg_username');
 $groundhogg_public_key = get_setting('groundhogg_public_key');
@@ -173,6 +181,9 @@ include __DIR__.'/header.php';
             </li>
             <li class="nav-item" role="presentation">
                 <button class="nav-link<?php if($active_tab==='statuses') echo ' active'; ?>" id="statuses-tab" data-bs-toggle="tab" data-bs-target="#statuses" type="button" role="tab">Statuses</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link<?php if($active_tab==='calendar') echo ' active'; ?>" id="calendar-tab" data-bs-toggle="tab" data-bs-target="#calendar" type="button" role="tab">Calendar</button>
             </li>
             <li class="nav-item" role="presentation">
                 <button class="nav-link<?php if($active_tab==='reset') echo ' active'; ?>" id="reset-tab" data-bs-toggle="tab" data-bs-target="#reset" type="button" role="tab">Reset</button>
@@ -386,6 +397,26 @@ include __DIR__.'/header.php';
                             </tbody>
                         </table>
                         <button type="button" class="btn btn-sm btn-secondary" id="addStatus">Add Status</button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="tab-pane fade<?php if($active_tab==='calendar') echo ' show active'; ?>" id="calendar" role="tabpanel" aria-labelledby="calendar-tab">
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="mb-0">Calendar Import</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label for="calendar_sheet_url" class="form-label">Google Sheet CSV URL</label>
+                            <input type="text" name="calendar_sheet_url" id="calendar_sheet_url" class="form-control" value="<?php echo htmlspecialchars($calendar_sheet_url); ?>">
+                            <div class="form-text">Public CSV link to the calendar sheet</div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="calendar_update_interval" class="form-label">Update Interval (hours)</label>
+                            <input type="number" name="calendar_update_interval" id="calendar_update_interval" class="form-control" value="<?php echo htmlspecialchars($calendar_update_interval); ?>">
+                        </div>
+                        <button class="btn btn-secondary" type="submit" name="force_calendar_update">Force Update</button>
                     </div>
                 </div>
             </div>

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -17,13 +17,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $errors[] = 'PIN already exists';
         } else {
-            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_token, first_name, last_name, phone, address, city, state, zip_code, country, marketing_report_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_token, hootsuite_campaign_tag, first_name, last_name, phone, address, city, state, zip_code, country, marketing_report_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
             $stmt->execute([
                 $_POST['name'],
                 $_POST['pin'],
                 $_POST['email'],
                 $_POST['folder'],
                 $_POST['hootsuite_token'],
+                $_POST['hootsuite_campaign_tag'] ?? null,
                 $_POST['first_name'] ?? null,
                 $_POST['last_name'] ?? null,
                 format_mobile_number($_POST['phone'] ?? ''),
@@ -259,6 +260,10 @@ include __DIR__.'/header.php';
                     <label for="hootsuite_token" class="form-label">Hootsuite Access Token</label>
                     <input type="text" name="hootsuite_token" id="hootsuite_token" class="form-control">
                     <div class="form-text">Optional: token used to fetch scheduled posts</div>
+                </div>
+                <div class="col-md-6">
+                    <label for="hootsuite_campaign_tag" class="form-label">Hootsuite Campaign Tag</label>
+                    <input type="text" name="hootsuite_campaign_tag" id="hootsuite_campaign_tag" class="form-control">
                 </div>
                 <div class="col-md-6">
                     <label for="marketing_report_url" class="form-label">Marketing Report URL</label>

--- a/cmuploader.sql
+++ b/cmuploader.sql
@@ -216,6 +216,7 @@ CREATE TABLE `stores` (
   `admin_email` varchar(255) DEFAULT NULL,
   `drive_folder` varchar(255) DEFAULT NULL,
   `hootsuite_token` varchar(255) DEFAULT NULL,
+  `hootsuite_campaign_tag` varchar(100) DEFAULT NULL,
   `first_name` varchar(100) DEFAULT NULL,
   `last_name` varchar(100) DEFAULT NULL,
   `phone` varchar(50) DEFAULT NULL,
@@ -231,11 +232,11 @@ CREATE TABLE `stores` (
 -- Dumping data for table `stores`
 --
 
-INSERT INTO `stores` (`id`, `name`, `pin`, `admin_email`, `drive_folder`, `hootsuite_token`, `first_name`, `last_name`, `phone`, `address`, `city`, `state`, `zip_code`, `country`, `marketing_report_url`) VALUES
-(1, 'test', '1111', 'test@none.com', '', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-(2, 'testing', '1234', 'test@none.com', '16FMaL4Lv0V6_ZVxBQRpg-3GaUyfeu0G3', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-(3, 'Petland Cosmick', '2547', 'cosmicktechnologies@gmail.com', '1srY5v90SaXNgWsl56K_e9F0YaSN43Hc-', '', 'Carley', 'Kuehner', '', '1147 Jacobsburg Road', 'Wind Gap', 'PA', '18091', 'United States', NULL),
-(4, 'Petland Phoenix', '2345', 'kim@cosmickmedia.com', '1VvZT3W4_ADzo1nRXPg98n8wOROIov9lC', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO `stores` (`id`, `name`, `pin`, `admin_email`, `drive_folder`, `hootsuite_token`, `hootsuite_campaign_tag`, `first_name`, `last_name`, `phone`, `address`, `city`, `state`, `zip_code`, `country`, `marketing_report_url`) VALUES
+(1, 'test', '1111', 'test@none.com', '', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+(2, 'testing', '1234', 'test@none.com', '16FMaL4Lv0V6_ZVxBQRpg-3GaUyfeu0G3', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+(3, 'Petland Cosmick', '2547', 'cosmicktechnologies@gmail.com', '1srY5v90SaXNgWsl56K_e9F0YaSN43Hc-', '', NULL, 'Carley', 'Kuehner', '', '1147 Jacobsburg Road', 'Wind Gap', 'PA', '18091', 'United States', NULL),
+(4, 'Petland Phoenix', '2345', 'kim@cosmickmedia.com', '1VvZT3W4_ADzo1nRXPg98n8wOROIov9lC', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 -- --------------------------------------------------------
 
@@ -419,6 +420,26 @@ CREATE TABLE `upload_status_history` (
 INSERT INTO `upload_status_history` (`id`, `upload_id`, `user_id`, `old_status_id`, `new_status_id`, `changed_at`) VALUES
 (1, 24, 1, 9, 21, '2025-07-14 15:10:08'),
 (2, 24, 1, 21, 20, '2025-07-14 16:51:33');
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `calendar`
+--
+
+CREATE TABLE `calendar` (
+  `id` int(11) NOT NULL,
+  `ext_id` varchar(50) NOT NULL,
+  `store_id` int(11) NOT NULL,
+  `text` text DEFAULT NULL,
+  `scheduled_time` datetime DEFAULT NULL,
+  `raw_json` text DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT current_timestamp()
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `calendar`
+--
 
 -- --------------------------------------------------------
 
@@ -630,6 +651,12 @@ ALTER TABLE `uploads`
 ALTER TABLE `upload_status_history`
   ADD CONSTRAINT `upload_status_history_ibfk_1` FOREIGN KEY (`upload_id`) REFERENCES `uploads` (`id`) ON DELETE CASCADE,
   ADD CONSTRAINT `upload_status_history_ibfk_2` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE;
+
+--
+-- Constraints for table `calendar`
+--
+ALTER TABLE `calendar`
+  ADD CONSTRAINT `calendar_ibfk_1` FOREIGN KEY (`store_id`) REFERENCES `stores` (`id`) ON DELETE CASCADE;
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -1,0 +1,60 @@
+<?php
+require_once __DIR__.'/db.php';
+require_once __DIR__.'/settings.php';
+
+function calendar_update(bool $force = false): array {
+    $sheetUrl = get_setting('calendar_sheet_url');
+    if (!$sheetUrl) {
+        return [false, 'No calendar sheet URL configured'];
+    }
+    $interval = (int)(get_setting('calendar_update_interval') ?: 24);
+    $last = get_setting('calendar_last_update');
+    if (!$force && $last && (time() - strtotime($last) < $interval * 3600)) {
+        return [false, 'Update not required yet'];
+    }
+
+    $csv = @file_get_contents($sheetUrl);
+    if ($csv === false) {
+        return [false, 'Failed to fetch sheet'];
+    }
+
+    $rows = array_map('str_getcsv', preg_split("/\r?\n/", trim($csv)));
+    $pdo = get_pdo();
+    $inserted = 0;
+    $storeStmt = $pdo->prepare('SELECT id FROM stores WHERE LOWER(hootsuite_campaign_tag)=?');
+    $checkStmt = $pdo->prepare('SELECT id FROM calendar WHERE ext_id=?');
+    $insStmt = $pdo->prepare('INSERT INTO calendar (ext_id, store_id, text, scheduled_time, raw_json) VALUES (?, ?, ?, ?, ?)');
+
+    foreach ($rows as $row) {
+        if (!isset($row[0])) continue;
+        $post = json_decode($row[0], true);
+        if (!$post || empty($post['id'])) continue;
+        $extId = $post['id'];
+        $checkStmt->execute([$extId]);
+        if ($checkStmt->fetch()) continue;
+        $tags = $post['tags'] ?? [];
+        if (!is_array($tags)) $tags = [];
+        $store_id = null;
+        foreach ($tags as $tag) {
+            $storeStmt->execute([strtolower($tag)]);
+            $sid = $storeStmt->fetchColumn();
+            if ($sid) { $store_id = $sid; break; }
+        }
+        if (!$store_id) continue;
+        $text = $post['text'] ?? '';
+        $scheduled = $post['scheduledSendTime'] ?? null;
+        if ($scheduled) $scheduled = date('Y-m-d H:i:s', strtotime($scheduled));
+        $insStmt->execute([$extId, $store_id, $text, $scheduled, json_encode($post)]);
+        $inserted++;
+    }
+
+    set_setting('calendar_last_update', date('Y-m-d H:i:s'));
+    return [true, "Inserted $inserted posts"];
+}
+
+function calendar_get_posts(int $store_id): array {
+    $pdo = get_pdo();
+    $stmt = $pdo->prepare('SELECT text, scheduled_time FROM calendar WHERE store_id=? ORDER BY scheduled_time DESC');
+    $stmt->execute([$store_id]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__.'/db.php';
+
+function get_setting(string $name) {
+    $pdo = get_pdo();
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE name=?');
+    $stmt->execute([$name]);
+    return $stmt->fetchColumn();
+}
+
+function set_setting(string $name, $value): void {
+    $pdo = get_pdo();
+    $stmt = $pdo->prepare('INSERT INTO settings (name,value) VALUES (?,?) ON DUPLICATE KEY UPDATE value=VALUES(value)');
+    $stmt->execute([$name, $value]);
+}

--- a/public/calendar.php
+++ b/public/calendar.php
@@ -1,6 +1,6 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
-require_once __DIR__.'/../lib/hootsuite.php';
+require_once __DIR__.'/../lib/calendar.php';
 require_once __DIR__.'/../lib/helpers.php';
 
 session_start();
@@ -13,13 +13,12 @@ if (!isset($_SESSION['store_id'])) {
 $store_id = $_SESSION['store_id'];
 $pdo = get_pdo();
 
-$stmt = $pdo->prepare('SELECT hootsuite_token, name FROM stores WHERE id = ?');
+$stmt = $pdo->prepare('SELECT name FROM stores WHERE id = ?');
 $stmt->execute([$store_id]);
 $store = $stmt->fetch();
 $store_name = $store['name'];
-$token = $store['hootsuite_token'];
 
-$posts = hootsuite_get_scheduled_posts($token);
+$posts = calendar_get_posts($store_id);
 
 include __DIR__.'/header.php';
 ?>
@@ -43,7 +42,7 @@ include __DIR__.'/header.php';
             <?php foreach ($posts as $p): ?>
                 <tr>
                     <td><?php echo htmlspecialchars($p['text'] ?? ''); ?></td>
-                    <td><?php echo htmlspecialchars($p['scheduledSendTime'] ?? ''); ?></td>
+                    <td><?php echo htmlspecialchars($p['scheduled_time'] ?? ''); ?></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>

--- a/scripts/update_calendar.php
+++ b/scripts/update_calendar.php
@@ -1,0 +1,6 @@
+<?php
+require_once __DIR__.'/../lib/calendar.php';
+
+$force = in_array('--force', $argv);
+[$ok, $msg] = calendar_update($force);
+echo ($ok ? 'SUCCESS: ' : 'ERROR: ') . $msg . "\n";

--- a/setup.php
+++ b/setup.php
@@ -21,6 +21,7 @@ $queries = [
         admin_email VARCHAR(255),
         drive_folder VARCHAR(255),
         hootsuite_token VARCHAR(255),
+        hootsuite_campaign_tag VARCHAR(100),
         first_name VARCHAR(100),
         last_name VARCHAR(100),
         phone VARCHAR(50),
@@ -127,6 +128,19 @@ $queries = [
         ip VARCHAR(45) NOT NULL,
         INDEX idx_created_at (created_at)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+
+    // Calendar table
+    "CREATE TABLE IF NOT EXISTS calendar (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        ext_id VARCHAR(50) NOT NULL UNIQUE,
+        store_id INT NOT NULL,
+        text TEXT,
+        scheduled_time DATETIME,
+        raw_json TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (store_id) REFERENCES stores(id) ON DELETE CASCADE,
+        INDEX idx_store_time (store_id, scheduled_time)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
 ];
 
 // Execute table creation queries
@@ -182,6 +196,13 @@ try {
 try {
     $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_token VARCHAR(255) AFTER drive_folder");
     echo "✓ Added hootsuite_token column to stores table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_campaign_tag VARCHAR(100) AFTER hootsuite_token");
+    echo "✓ Added hootsuite_campaign_tag column to stores table\n";
 } catch (PDOException $e) {
     // Column might already exist
 }
@@ -299,7 +320,10 @@ $defaultSettings = [
     'company_city' => '',
     'company_state' => '',
     'company_zip' => '',
-    'company_country' => ''
+    'company_country' => '',
+    'calendar_sheet_url' => '',
+    'calendar_update_interval' => '24',
+    'calendar_last_update' => ''
 ];
 
 foreach ($defaultSettings as $name => $value) {

--- a/update_database.php
+++ b/update_database.php
@@ -58,7 +58,10 @@ $defaultSettings = [
     'company_city' => '',
     'company_state' => '',
     'company_zip' => '',
-    'company_country' => ''
+    'company_country' => '',
+    'calendar_sheet_url' => '',
+    'calendar_update_interval' => '24',
+    'calendar_last_update' => ''
 ];
 
 foreach ($defaultSettings as $name => $value) {
@@ -184,6 +187,13 @@ try {
     echo "✓ Added hootsuite_token column to stores table\n";
 } catch (PDOException $e) {
     echo "• hootsuite_token column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_campaign_tag VARCHAR(100) AFTER hootsuite_token");
+    echo "✓ Added hootsuite_campaign_tag column to stores table\n";
+} catch (PDOException $e) {
+    echo "• hootsuite_campaign_tag column might already exist\n";
 }
 
 // New contact columns for stores
@@ -352,6 +362,24 @@ try {
     echo "✓ Created upload_status_history table\n";
 } catch (PDOException $e) {
     echo "✗ Error creating upload_status_history table: " . $e->getMessage() . "\n";
+}
+
+// Create calendar table
+try {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS calendar (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        ext_id VARCHAR(50) NOT NULL UNIQUE,
+        store_id INT NOT NULL,
+        text TEXT,
+        scheduled_time DATETIME,
+        raw_json TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (store_id) REFERENCES stores(id) ON DELETE CASCADE,
+        INDEX idx_store_time (store_id, scheduled_time)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+    echo "✓ Created calendar table\n";
+} catch (PDOException $e) {
+    echo "✗ Error creating calendar table: " . $e->getMessage() . "\n";
 }
 
 echo "\n✓ Database update complete!\n";


### PR DESCRIPTION
## Summary
- introduce generic settings helper
- add calendar sync library and CLI script
- extend admin settings with calendar options and force update button
- store campaign tag on stores and update create/edit forms
- import calendar posts from sheet into DB table
- display calendar posts per store
- update setup and update scripts

## Testing
- `php -l lib/calendar.php`
- `php -l lib/settings.php`
- `php -l scripts/update_calendar.php`
- `php -l admin/settings.php`
- `php -l admin/stores.php`
- `php -l admin/edit_store.php`
- `php -l public/calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_687724c800e08326acaa4daced00cd65