### PR TITLE
Fix duplicate function issues and improve feedback

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -3,6 +3,7 @@ require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/auth.php';
 require_once __DIR__.'/../lib/groundhogg.php';
 require_once __DIR__.'/../lib/settings.php';
+$test_action = '';
 require_login();
 $pdo = get_pdo();
 
@@ -99,10 +100,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif (isset($_POST['test_groundhogg'])) {
         [$ok, $msg] = test_groundhogg_connection();
         $test_result = [$ok, $msg];
+        $test_action = 'groundhogg';
     } elseif (isset($_POST['force_calendar_update'])) {
         require_once __DIR__.'/../lib/calendar.php';
         [$ok, $msg] = calendar_update(true);
         $test_result = [$ok, $msg];
+        $test_action = 'calendar';
     }
     $success = true;
 }
@@ -149,14 +152,26 @@ include __DIR__.'/header.php';
     </div>
 <?php endif; ?>
 <?php if ($test_result !== null): ?>
-    <?php if ($test_result[0]): ?>
-        <div class="alert alert-success alert-dismissible fade show" role="alert">Dripley connection successful!
-            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-        </div>
-    <?php else: ?>
-        <div class="alert alert-danger alert-dismissible fade show" role="alert">Dripley connection failed: <?php echo htmlspecialchars($test_result[1]); ?>
-            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-        </div>
+    <?php if ($test_action === 'groundhogg'): ?>
+        <?php if ($test_result[0]): ?>
+            <div class="alert alert-success alert-dismissible fade show" role="alert">Dripley connection successful!
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+        <?php else: ?>
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">Dripley connection failed: <?php echo htmlspecialchars($test_result[1]); ?>
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+        <?php endif; ?>
+    <?php elseif ($test_action === 'calendar'): ?>
+        <?php if ($test_result[0]): ?>
+            <div class="alert alert-success alert-dismissible fade show" role="alert">Calendar update successful: <?php echo htmlspecialchars($test_result[1]); ?>
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+        <?php else: ?>
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">Calendar update failed: <?php echo htmlspecialchars($test_result[1]); ?>
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+        <?php endif; ?>
     <?php endif; ?>
 <?php endif; ?>
 

--- a/lib/settings.php
+++ b/lib/settings.php
@@ -1,15 +1,19 @@
 <?php
 require_once __DIR__.'/db.php';
 
-function get_setting(string $name) {
-    $pdo = get_pdo();
-    $stmt = $pdo->prepare('SELECT value FROM settings WHERE name=?');
-    $stmt->execute([$name]);
-    return $stmt->fetchColumn();
+if (!function_exists('get_setting')) {
+    function get_setting(string $name) {
+        $pdo = get_pdo();
+        $stmt = $pdo->prepare('SELECT value FROM settings WHERE name=?');
+        $stmt->execute([$name]);
+        return $stmt->fetchColumn();
+    }
 }
 
-function set_setting(string $name, $value): void {
-    $pdo = get_pdo();
-    $stmt = $pdo->prepare('INSERT INTO settings (name,value) VALUES (?,?) ON DUPLICATE KEY UPDATE value=VALUES(value)');
-    $stmt->execute([$name, $value]);
+if (!function_exists('set_setting')) {
+    function set_setting(string $name, $value): void {
+        $pdo = get_pdo();
+        $stmt = $pdo->prepare('INSERT INTO settings (name,value) VALUES (?,?) ON DUPLICATE KEY UPDATE value=VALUES(value)');
+        $stmt->execute([$name, $value]);
+    }
 }


### PR DESCRIPTION
## Summary
- avoid duplicate function declarations for `get_setting` and `set_setting`
- show a different alert when forcing the calendar update

## Testing
- `php -l lib/settings.php`
- `php -l admin/settings.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68772ce0ab84832680ce00957d0b1326