### PR TITLE
Improve calendar JWT signing

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -489,6 +489,12 @@ include __DIR__.'/header.php';
                 document.getElementById('active_tab').value = e.target.id.replace('-tab','');
             });
         });
+        document.querySelector('form').addEventListener('submit', () => {
+            const activeBtn = document.querySelector('#settingsTabs .nav-link.active');
+            if (activeBtn) {
+                document.getElementById('active_tab').value = activeBtn.id.replace('-tab','');
+            }
+        });
     </script>
 
 <?php include __DIR__.'/footer.php'; ?>

--- a/lib/sheets.php
+++ b/lib/sheets.php
@@ -10,10 +10,14 @@ function sheets_get_access_token() {
     }
     $creds = json_decode(file_get_contents($service_account_file), true);
 
-    $header = json_encode([
+    $headerArr = [
         'alg' => 'RS256',
         'typ' => 'JWT'
-    ]);
+    ];
+    if (!empty($creds['private_key_id'])) {
+        $headerArr['kid'] = $creds['private_key_id'];
+    }
+    $header = json_encode($headerArr);
 
     $now = time();
     $claims = json_encode([
@@ -28,7 +32,15 @@ function sheets_get_access_token() {
     $base64UrlClaims = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($claims));
 
     $signature = '';
-    openssl_sign($base64UrlHeader . '.' . $base64UrlClaims, $signature, $creds['private_key'], OPENSSL_ALGO_SHA256);
+    $pkey = openssl_pkey_get_private($creds['private_key']);
+    if (!$pkey) {
+        throw new Exception('Invalid private key');
+    }
+    $ok = openssl_sign($base64UrlHeader . '.' . $base64UrlClaims, $signature, $pkey, OPENSSL_ALGO_SHA256);
+    openssl_free_key($pkey);
+    if (!$ok) {
+        throw new Exception('Failed to sign JWT');
+    }
     $base64UrlSignature = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode($signature));
 
     $jwt = $base64UrlHeader . '.' . $base64UrlClaims . '.' . $base64UrlSignature;


### PR DESCRIPTION
## Summary
- handle JWT signing errors for Google Sheets
- improve Drive JWT signing with key id
- keep active tab after saving settings

## Testing
- `php -l lib/sheets.php`
- `php -l lib/drive.php`
- `php -l admin/settings.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68772ea2686883268e66c8f49612f225