### PR TITLE
Allow full Google Sheets URL for calendar import

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ To sync new store contacts with your Groundhogg installation, open **Admin → S
 After saving, use the **Test Connection** button to verify communication with your Groundhogg REST API. If public key credentials are provided, the advanced authentication method is used.
 
 If you need to troubleshoot API issues, enable **Debug Logging** in the settings panel. When enabled, detailed request and response information is written to `logs/groundhogg.log` in the project root.
+
+### Calendar Import
+
+To populate the calendar from Google Sheets, open **Admin → Settings** and paste the sheet's public URL in the **Google Sheet URL** field. The application automatically converts the standard editing link into the required CSV export format.

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -415,9 +415,9 @@ include __DIR__.'/header.php';
                     </div>
                     <div class="card-body">
                         <div class="mb-3">
-                            <label for="calendar_sheet_url" class="form-label">Google Sheet CSV URL</label>
+                            <label for="calendar_sheet_url" class="form-label">Google Sheet URL</label>
                             <input type="text" name="calendar_sheet_url" id="calendar_sheet_url" class="form-control" value="<?php echo htmlspecialchars($calendar_sheet_url); ?>">
-                            <div class="form-text">Public CSV link to the calendar sheet</div>
+                            <div class="form-text">Paste the public sheet link; export URL is handled automatically</div>
                         </div>
                         <div class="mb-3">
                             <label for="calendar_sheet_id" class="form-label">Google Sheet ID</label>

--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -23,6 +23,16 @@ function calendar_update(bool $force = false): array {
             return [false, $e->getMessage()];
         }
     } else {
+        if (preg_match('#docs.google.com\/spreadsheets\/d\/([^\/]+)#', $sheetUrl, $m)) {
+            $gid = null;
+            if (preg_match('#[?&]gid=(\d+)#', $sheetUrl, $g)) {
+                $gid = $g[1];
+            }
+            $sheetUrl = 'https://docs.google.com/spreadsheets/d/' . $m[1] . '/export?format=csv';
+            if ($gid !== null) {
+                $sheetUrl .= '&gid=' . $gid;
+            }
+        }
         $csv = @file_get_contents($sheetUrl);
         if ($csv === false) {
             return [false, 'Failed to fetch sheet'];


### PR DESCRIPTION
## Summary
- convert a standard Google Sheets link to a CSV export URL
- update Calendar settings UI
- document Google Sheets URL usage in README

## Testing
- `php -l lib/calendar.php`
- `php -l admin/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_6877367d7edc8326ba446f5ece5595c1