### PR TITLE
Remove Google Sheet ID from settings

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -47,7 +47,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'company_zip'             => trim($_POST['company_zip'] ?? ''),
         'company_country'         => trim($_POST['company_country'] ?? ''),
         'calendar_sheet_url'      => trim($_POST['calendar_sheet_url'] ?? ''),
-        'calendar_sheet_id'       => trim($_POST['calendar_sheet_id'] ?? ''),
         'calendar_sheet_range'    => trim($_POST['calendar_sheet_range'] ?? 'Sheet1!A:A'),
         'calendar_update_interval'=> trim($_POST['calendar_update_interval'] ?? '24')
     ];
@@ -128,7 +127,6 @@ $company_state = get_setting('company_state') ?: '';
 $company_zip = get_setting('company_zip') ?: '';
 $company_country = get_setting('company_country') ?: '';
 $calendar_sheet_url = get_setting('calendar_sheet_url') ?: '';
-$calendar_sheet_id = get_setting('calendar_sheet_id') ?: '';
 $calendar_sheet_range = get_setting('calendar_sheet_range') ?: 'Sheet1!A:A';
 $calendar_update_interval = get_setting('calendar_update_interval') ?: '24';
 $groundhogg_site_url = get_setting('groundhogg_site_url');
@@ -418,11 +416,6 @@ include __DIR__.'/header.php';
                             <label for="calendar_sheet_url" class="form-label">Google Sheet URL</label>
                             <input type="text" name="calendar_sheet_url" id="calendar_sheet_url" class="form-control" value="<?php echo htmlspecialchars($calendar_sheet_url); ?>">
                             <div class="form-text">Paste the public sheet link; export URL is handled automatically</div>
-                        </div>
-                        <div class="mb-3">
-                            <label for="calendar_sheet_id" class="form-label">Google Sheet ID</label>
-                            <input type="text" name="calendar_sheet_id" id="calendar_sheet_id" class="form-control" value="<?php echo htmlspecialchars($calendar_sheet_id); ?>">
-                            <div class="form-text">If provided, data will be fetched using the service account</div>
                         </div>
                         <div class="mb-3">
                             <label for="calendar_sheet_range" class="form-label">Sheet Range</label>

--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -16,13 +16,7 @@ function calendar_update(bool $force = false): array {
         return [false, 'Update not required yet'];
     }
 
-    if ($sheetId) {
-        try {
-            $rows = sheets_fetch_rows($sheetId, $sheetRange);
-        } catch (Exception $e) {
-            return [false, $e->getMessage()];
-        }
-    } else {
+    if ($sheetUrl) {
         if (preg_match('#docs.google.com\/spreadsheets\/d\/([^\/]+)#', $sheetUrl, $m)) {
             $gid = null;
             if (preg_match('#[?&]gid=(\d+)#', $sheetUrl, $g)) {
@@ -38,6 +32,12 @@ function calendar_update(bool $force = false): array {
             return [false, 'Failed to fetch sheet'];
         }
         $rows = array_map('str_getcsv', preg_split("/\r?\n/", trim($csv)));
+    } elseif ($sheetId) {
+        try {
+            $rows = sheets_fetch_rows($sheetId, $sheetRange);
+        } catch (Exception $e) {
+            return [false, $e->getMessage()];
+        }
     }
 
     $pdo = get_pdo();

--- a/setup.php
+++ b/setup.php
@@ -322,7 +322,6 @@ $defaultSettings = [
     'company_zip' => '',
     'company_country' => '',
     'calendar_sheet_url' => '',
-    'calendar_sheet_id' => '',
     'calendar_sheet_range' => 'Sheet1!A:A',
     'calendar_update_interval' => '24',
     'calendar_last_update' => ''

--- a/update_database.php
+++ b/update_database.php
@@ -60,7 +60,6 @@ $defaultSettings = [
     'company_zip' => '',
     'company_country' => '',
     'calendar_sheet_url' => '',
-    'calendar_sheet_id' => '',
     'calendar_sheet_range' => 'Sheet1!A:A',
     'calendar_update_interval' => '24',
     'calendar_last_update' => ''


### PR DESCRIPTION
## Summary
- drop `calendar_sheet_id` from default settings and admin UI
- prefer the Sheet URL when updating calendar data

## Testing
- `php -l admin/settings.php`
- `php -l lib/calendar.php`
- `php -l setup.php`
- `php -l update_database.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687737e74ec08326981a4e9542798cf4