### PR TITLE
Implement interactive calendar view

### DIFF
--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -161,7 +161,7 @@ function calendar_get_posts(int $store_id): array {
     } catch (PDOException $e) {
         $column = 'scheduled_time';
     }
-    $stmt = $pdo->prepare("SELECT text, $column FROM calendar WHERE store_id=? ORDER BY $column DESC");
+    $stmt = $pdo->prepare("SELECT text, $column, social_profile_id, media_urls FROM calendar WHERE store_id=? ORDER BY $column DESC");
     $stmt->execute([$store_id]);
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }

--- a/public/calendar.php
+++ b/public/calendar.php
@@ -20,6 +20,68 @@ $store_name = $store['name'];
 
 $posts = calendar_get_posts($store_id);
 
+$events = [];
+foreach ($posts as $p) {
+    $time = $p['scheduled_send_time'] ?? $p['scheduled_time'] ?? null;
+    $img = '';
+    if (!empty($p['media_urls'])) {
+        $urls = json_decode($p['media_urls'], true);
+        if (is_array($urls) && !empty($urls)) {
+            $img = $urls[0];
+        }
+    }
+    $events[] = [
+        'title' => $p['text'] ?? '',
+        'start' => $time,
+        'extendedProps' => [
+            'image' => $img,
+            'icon' => 'bi-share'
+        ]
+    ];
+}
+
+$events_json = json_encode($events);
+
+$extra_head = <<<HTML
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css">
+<style>
+#calendar{max-width:900px;margin:0 auto;}
+.fc-custom-event{display:flex;align-items:center;}
+.fc-custom-event img{width:20px;height:20px;object-fit:cover;margin-right:2px;}
+</style>
+HTML;
+
+$extra_js = <<<JS
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var calEl = document.getElementById('calendar');
+    var calendar = new FullCalendar.Calendar(calEl, {
+        initialView: 'dayGridMonth',
+        headerToolbar: { left: 'prev,next today', center: 'title', right: '' },
+        events: $events_json,
+        eventContent: function(arg) {
+            var cont = document.createElement('div');
+            cont.className = 'fc-custom-event';
+            if (arg.event.extendedProps.image) {
+                var img = document.createElement('img');
+                img.src = arg.event.extendedProps.image;
+                cont.appendChild(img);
+            }
+            var icon = document.createElement('i');
+            icon.className = 'bi ' + (arg.event.extendedProps.icon || 'bi-share') + ' me-1';
+            cont.appendChild(icon);
+            var span = document.createElement('span');
+            span.textContent = arg.event.title;
+            cont.appendChild(span);
+            return { domNodes: [cont] };
+        }
+    });
+    calendar.render();
+});
+</script>
+JS;
+
 include __DIR__.'/header.php';
 ?>
 <div class="d-flex justify-content-between align-items-center mb-4">
@@ -30,24 +92,7 @@ include __DIR__.'/header.php';
 <?php if (empty($posts)): ?>
     <div class="alert alert-info">No scheduled posts found.</div>
 <?php else: ?>
-    <div class="table-responsive">
-        <table class="table table-hover">
-            <thead>
-            <tr>
-                <th>Message</th>
-                <th>Scheduled Time</th>
-            </tr>
-            </thead>
-            <tbody>
-            <?php foreach ($posts as $p): ?>
-                <tr>
-                    <td><?php echo htmlspecialchars($p['text'] ?? ''); ?></td>
-                    <td><?php echo htmlspecialchars($p['scheduled_time'] ?? ''); ?></td>
-                </tr>
-            <?php endforeach; ?>
-            </tbody>
-        </table>
-    </div>
+    <div id="calendar"></div>
 <?php endif; ?>
 
 <?php include __DIR__.'/footer.php'; ?>

--- a/public/footer.php
+++ b/public/footer.php
@@ -21,5 +21,6 @@ function checkNotifications(){
 setInterval(checkNotifications,5000);
 checkNotifications();
 </script>
+<?php if(isset($extra_js)) echo $extra_js; ?>
 </body>
 </html>

--- a/public/header.php
+++ b/public/header.php
@@ -16,6 +16,7 @@ if (!isset($_SESSION)) { session_start(); }
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="inc/css/style.css">
+    <?php if(isset($extra_head)) echo $extra_head; ?>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark">


### PR DESCRIPTION
## Summary
- make calendar table return social_profile_id and media_urls
- add calendar events to interactive JS calendar
- support page-specific assets in header/footer

## Testing
- `npm install`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6877411a1bc08326bde5d72c08e9c600