### PR TITLE
Improve social calendar UI

### DIFF
--- a/lib/hootsuite.php
+++ b/lib/hootsuite.php
@@ -28,3 +28,33 @@ function hootsuite_get_scheduled_posts(?string $token): array {
     }
     return $data['data'];
 }
+
+/**
+ * Fetch all social profiles for the authenticated user.
+ */
+function hootsuite_get_social_profiles(?string $token): array {
+    if (empty($token)) {
+        return [];
+    }
+
+    $url = 'https://platform.hootsuite.com/v1/socialProfiles';
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => [
+            'Authorization: Bearer ' . $token,
+            'Content-Type: application/json'
+        ]
+    ]);
+    $response = curl_exec($ch);
+    if ($response === false) {
+        curl_close($ch);
+        return [];
+    }
+    curl_close($ch);
+    $data = json_decode($response, true);
+    if (!is_array($data) || !isset($data['data'])) {
+        return [];
+    }
+    return $data['data'];
+}

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -58,3 +58,9 @@ table th, table td {
 .mention-box{position:absolute;background:#fff;border:1px solid #ccc;z-index:1000;max-height:150px;overflow-y:auto;padding:2px;display:none;}
 .mention-box div{padding:2px 4px;cursor:pointer;}
 .mention-box div:hover{background:#f0f0f0;}
+
+/* Calendar styles */
+#calendar .fc-daygrid-event{
+    border-radius:4px;
+    padding:2px 4px;
+}


### PR DESCRIPTION
## Summary
- add helper to fetch Hootsuite social profiles
- update calendar to show platform icons
- render a Bootstrap modal with post details on click
- adjust calendar styling and width
- add calendar styles to stylesheet

## Testing
- `php -l public/calendar.php`
- `php -l lib/hootsuite.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6877443728d8832689f322cd0a5240c4