### PR TITLE
Improve calendar event details

### DIFF
--- a/public/calendar.php
+++ b/public/calendar.php
@@ -31,7 +31,11 @@ $posts = calendar_get_posts($store_id);
 
 $network_map = [];
 foreach ($pdo->query('SELECT name, icon, color FROM social_networks') as $n) {
-    $network_map[strtolower($n['name'])] = ['icon'=>$n['icon'], 'color'=>$n['color']];
+    $network_map[strtolower($n['name'])] = [
+        'icon'  => $n['icon'],
+        'color' => $n['color'],
+        'name'  => $n['name']
+    ];
 }
 
 $events = [];
@@ -64,7 +68,8 @@ foreach ($posts as $p) {
         }
     }
     $icon = $network['icon'] ?? '';
-    $color = $network['color'] ?? '#6c757d';
+    $color = $network['color'] ?? '#2c3e50';
+    $network_name = $network['name'] ?? '';
     $events[] = [
         'title' => $p['text'] ?? '',
         'start' => $time,
@@ -74,7 +79,9 @@ foreach ($posts as $p) {
             'image' => $img,
             'icon'  => $icon,
             'text'  => $p['text'] ?? '',
-            'time'  => $time
+            'time'  => $time,
+            'network' => $network_name,
+            'tags' => $tags
         ]
     ];
 }
@@ -89,6 +96,9 @@ $extra_head = <<<HTML
 .fc-custom-event img{width:20px;height:20px;object-fit:cover;margin-right:4px;border-radius:4px;}
 .fc-daygrid-event{color:#fff;}
 .fc-toolbar-title{color:#2c3e50;}
+.fc .fc-button-primary{background-color:#2c3e50;border-color:#2c3e50;}
+.fc .fc-button-primary:not(:disabled).fc-button-active,
+.fc .fc-button-primary:not(:disabled):active{background-color:#1a252f;border-color:#1a252f;}
 </style>
 HTML;
 
@@ -136,7 +146,13 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             html += '<p>' + (e.extendedProps.text || '') + '</p>';
             if(e.extendedProps.time){
-                html += '<p><small>' + new Date(e.extendedProps.time).toLocaleString() + '</small></p>';
+                html += '<p><strong>Scheduled Date:</strong> ' + new Date(e.extendedProps.time).toLocaleString() + '</p>';
+            }
+            if(e.extendedProps.tags && e.extendedProps.tags.length){
+                html += '<p><strong>Tags:</strong> ' + e.extendedProps.tags.join(', ') + '</p>';
+            }
+            if(e.extendedProps.network){
+                html += '<p><strong>Social Network:</strong> ' + e.extendedProps.network + '</p>';
             }
             body.innerHTML = html;
             new bootstrap.Modal(document.getElementById('eventModal')).show();

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -63,4 +63,5 @@ table th, table td {
 #calendar .fc-daygrid-event{
     border-radius:4px;
     padding:2px 4px;
+    cursor:pointer;
 }


### PR DESCRIPTION
## Summary
- style calendar buttons with site colors
- detect social network name, color and icon by tag
- show scheduled date, tags, and network in modal
- style calendar events clickable

## Testing
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6877c77af728832690aeef5c58e83253