### PR TITLE
Add social network styles for calendar

### DIFF
--- a/public/calendar.php
+++ b/public/calendar.php
@@ -70,11 +70,16 @@ foreach ($posts as $p) {
     $icon = $network['icon'] ?? '';
     $color = $network['color'] ?? '#2c3e50';
     $network_name = $network['name'] ?? '';
+    $class = '';
+    if ($network_name) {
+        $class = 'social-' . preg_replace('/[^a-z0-9]+/', '-', strtolower($network_name));
+    }
     $events[] = [
         'title' => $p['text'] ?? '',
         'start' => $time,
         'backgroundColor' => $color,
         'borderColor' => $color,
+        'classNames' => $class ? [$class] : [],
         'extendedProps' => [
             'image' => $img,
             'icon'  => $icon,

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -65,3 +65,20 @@ table th, table td {
     padding:2px 4px;
     cursor:pointer;
 }
+
+/* Social network color classes */
+#calendar .social-facebook{background-color:#1877f2;border-color:#1877f2;}
+#calendar .social-instagram{background-color:#c13584;border-color:#c13584;}
+#calendar .social-x{background-color:#000000;border-color:#000000;}
+#calendar .social-tiktok{background-color:#69c9d0;border-color:#69c9d0;}
+#calendar .social-snapchat{background-color:#fffc00;border-color:#fffc00;color:#000;}
+#calendar .social-linkedin{background-color:#0a66c2;border-color:#0a66c2;}
+#calendar .social-youtube{background-color:#ff0000;border-color:#ff0000;}
+#calendar .social-pinterest{background-color:#e60023;border-color:#e60023;}
+#calendar .social-whatsapp{background-color:#25d366;border-color:#25d366;}
+#calendar .social-telegram{background-color:#0088cc;border-color:#0088cc;}
+#calendar .social-reddit{background-color:#ff4500;border-color:#ff4500;}
+#calendar .social-discord{background-color:#5865f2;border-color:#5865f2;}
+#calendar .social-threads{background-color:#ff0040;border-color:#ff0040;}
+#calendar .social-tumblr{background-color:#36465d;border-color:#36465d;}
+#calendar .social-twitch{background-color:#6441a5;border-color:#6441a5;}


### PR DESCRIPTION
## Summary
- dynamically assign social media classes to calendar events
- add CSS color rules for a variety of social networks

## Testing
- `php -l public/calendar.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6877caa21714832698cab290fe07a50a