### PR TITLE
Fix calendar image parsing

### DIFF
--- a/public/calendar.php
+++ b/public/calendar.php
@@ -43,13 +43,13 @@ foreach ($posts as $p) {
     $time = $p['scheduled_send_time'] ?? $p['scheduled_time'] ?? null;
     $img = '';
     if (!empty($p['media_urls'])) {
-        $urls = json_decode($p['media_urls'], true);
+        $urls = maybe_json_decode($p['media_urls']);
         if (is_array($urls) && !empty($urls)) {
             $img = $urls[0];
         }
     }
     if (!$img && !empty($p['media_thumb_urls'])) {
-        $urls = json_decode($p['media_thumb_urls'], true);
+        $urls = maybe_json_decode($p['media_thumb_urls']);
         if (is_array($urls) && !empty($urls)) {
             $img = $urls[0];
         }


### PR DESCRIPTION
## Summary
- fix media URL decoding for calendar events

## Testing
- `php -l public/calendar.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6877cc8091d883268afcc4b017bd0b0c