### PR TITLE
Store media URLs as plain list

### DIFF
--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -264,8 +264,8 @@ function calendar_update(bool $force = false): array {
             $urls = calendar_cache_media($urls, $dir, $scheduled);
             $thumbs = calendar_cache_media($thumbs, $dir, $scheduled);
         }
-        $media_urls = json_encode($urls);
-        $media_thumb_urls = json_encode($thumbs);
+        $media_urls = implode(',', $urls);
+        $media_thumb_urls = implode(',', $thumbs);
         $media = json_encode($media_arr);
         $webhook_urls = isset($post['webhookUrls']) ? json_encode($post['webhookUrls']) : null;
         $tags_json = json_encode($tags);

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -98,3 +98,32 @@ function maybe_json_decode($val) {
     }
     return $val;
 }
+
+/**
+ * Convert a value to an array of strings.
+ *
+ * Accepts arrays, JSON-encoded strings or comma separated lists. Whitespace
+ * is trimmed from each element and empty values are removed.
+ *
+ * @param mixed $val Potential array representation
+ * @return array Array of strings
+ */
+function to_string_array($val): array {
+    if (is_array($val)) {
+        return array_values(array_filter(array_map('trim', $val), 'strlen'));
+    }
+
+    if (is_string($val)) {
+        $trim = trim($val);
+        if ($trim === '') return [];
+
+        $decoded = json_decode($trim, true);
+        if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+            return to_string_array($decoded);
+        }
+
+        return array_values(array_filter(array_map('trim', explode(',', $trim)), 'strlen'));
+    }
+
+    return [];
+}

--- a/public/calendar.php
+++ b/public/calendar.php
@@ -43,14 +43,14 @@ foreach ($posts as $p) {
     $time = $p['scheduled_send_time'] ?? $p['scheduled_time'] ?? null;
     $img = '';
     if (!empty($p['media_urls'])) {
-        $urls = maybe_json_decode($p['media_urls']);
-        if (is_array($urls) && !empty($urls)) {
+        $urls = to_string_array($p['media_urls']);
+        if (!empty($urls)) {
             $img = $urls[0];
         }
     }
     if (!$img && !empty($p['media_thumb_urls'])) {
-        $urls = maybe_json_decode($p['media_thumb_urls']);
-        if (is_array($urls) && !empty($urls)) {
+        $urls = to_string_array($p['media_thumb_urls']);
+        if (!empty($urls)) {
             $img = $urls[0];
         }
     }


### PR DESCRIPTION
## Summary
- parse values to arrays using new `to_string_array()` helper
- store media URLs as comma-separated strings instead of JSON
- read stored URLs using the new helper when building the calendar view

## Testing
- `php -l lib/helpers.php`
- `php -l lib/calendar.php`
- `php -l public/calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_6877f1beec988326bc3f6deb5b399b8e