### PR TITLE
Fix public calendar image paths

### DIFF
--- a/public/calendar.php
+++ b/public/calendar.php
@@ -54,6 +54,9 @@ foreach ($posts as $p) {
             $img = $urls[0];
         }
     }
+    if ($img && str_starts_with($img, '/calendar_media/')) {
+        $img = '/public' . $img;
+    }
     $tags = [];
     if (!empty($p['tags'])) {
         $tags = json_decode($p['tags'], true);


### PR DESCRIPTION
## Summary
- ensure calendar images and thumbnails resolve in public calendar view

## Testing
- `php -l public/calendar.php`

------
https://chatgpt.com/codex/tasks/task_e_6877f66beedc8326a33470b893dc1e37