### PR TITLE
Update calendar settings and Hootsuite tag

### DIFF
--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -231,13 +231,10 @@ include __DIR__.'/header.php';
                 <label for="folder" class="form-label">Drive Folder ID</label>
                 <input type="text" name="folder" id="folder" class="form-control" value="<?php echo htmlspecialchars($store['drive_folder']); ?>">
             </div>
+            <input type="hidden" name="hootsuite_token" id="hootsuite_token" value="<?php echo htmlspecialchars($store['hootsuite_token']); ?>">
             <div class="col-md-6">
-                <label for="hootsuite_token" class="form-label">Hootsuite Access Token</label>
-                <input type="text" name="hootsuite_token" id="hootsuite_token" class="form-control" value="<?php echo htmlspecialchars($store['hootsuite_token']); ?>">
-            </div>
-            <div class="col-md-6">
-                <label for="hootsuite_campaign_tag" class="form-label">Hootsuite Campaign Tag</label>
-                <input type="text" name="hootsuite_campaign_tag" id="hootsuite_campaign_tag" class="form-control" value="<?php echo htmlspecialchars($store['hootsuite_campaign_tag']); ?>">
+                <label for="hootsuite_campaign_tag" class="form-label">Hootsuite Tag</label>
+                <input type="text" name="hootsuite_campaign_tag" id="hootsuite_campaign_tag" class="form-control" placeholder="do not put spaces and put lowercase, this must match the hootsuite tag" value="<?php echo htmlspecialchars($store['hootsuite_campaign_tag']); ?>">
             </div>
         </div>
     </div>

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -467,7 +467,7 @@ include __DIR__.'/header.php';
                     <div class="card-body">
                         <table class="table" id="networkTable">
                             <thead>
-                            <tr><th>Name</th><th>Icon Class</th><th>Color</th><th></th></tr>
+                            <tr><th>Name</th><th>Icon Class</th><th></th></tr>
                             </thead>
                             <tbody>
                             <?php foreach ($networks as $n): ?>
@@ -476,8 +476,10 @@ include __DIR__.'/header.php';
                                         <input type="hidden" name="network_id[]" value="<?php echo $n['id']; ?>">
                                         <input type="text" name="network_name[]" class="form-control" value="<?php echo htmlspecialchars($n['name']); ?>">
                                     </td>
-                                    <td><input type="text" name="network_icon[]" class="form-control" value="<?php echo htmlspecialchars($n['icon']); ?>"></td>
-                                    <td><input type="color" name="network_color[]" class="form-control form-control-color" value="<?php echo htmlspecialchars($n['color']); ?>"></td>
+                                    <td>
+                                        <input type="text" name="network_icon[]" class="form-control" value="<?php echo htmlspecialchars($n['icon']); ?>">
+                                        <input type="hidden" name="network_color[]" value="<?php echo htmlspecialchars($n['color']); ?>">
+                                    </td>
                                     <td><button type="button" class="btn btn-sm btn-danger remove-network">Delete</button></td>
                                 </tr>
                             <?php endforeach; ?>
@@ -538,8 +540,10 @@ include __DIR__.'/header.php';
                         <input type="hidden" name="network_id[]" value="">
                         <input type="text" name="network_name[]" class="form-control">
                     </td>
-                    <td><input type="text" name="network_icon[]" class="form-control" value=""></td>
-                    <td><input type="color" name="network_color[]" class="form-control form-control-color" value="#000000"></td>
+                    <td>
+                        <input type="text" name="network_icon[]" class="form-control" value="">
+                        <input type="hidden" name="network_color[]" value="#000000">
+                    </td>
                     <td><button type="button" class="btn btn-sm btn-danger remove-network">Delete</button></td>
                 `;
                 tbody.appendChild(row);


### PR DESCRIPTION
## Summary
- remove color picker from the Calendar tab social network table
- keep color values hidden so settings remain intact
- hide Hootsuite access token field
- rename Hootsuite campaign tag label and add helpful placeholder
- ensure marketing report iframe remains available when URL exists

## Testing
- `php -l admin/settings.php`
- `php -l admin/edit_store.php`
- `php -l public/marketing.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68780bdb6bdc8326a26c5332f463df07