### PR TITLE
Fix Hootsuite field names on add store form

### DIFF
--- a/admin/stores.php
+++ b/admin/stores.php
@@ -17,13 +17,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $errors[] = 'PIN already exists';
         } else {
-            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_token, hootsuite_campaign_tag, first_name, last_name, phone, address, city, state, zip_code, country, marketing_report_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_campaign_tag, first_name, last_name, phone, address, city, state, zip_code, country, marketing_report_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
             $stmt->execute([
                 $_POST['name'],
                 $_POST['pin'],
                 $_POST['email'],
                 $_POST['folder'],
-                $_POST['hootsuite_token'],
                 $_POST['hootsuite_campaign_tag'] ?? null,
                 $_POST['first_name'] ?? null,
                 $_POST['last_name'] ?? null,
@@ -257,12 +256,7 @@ include __DIR__.'/header.php';
                     <div class="form-text">Leave blank to auto-create on first upload</div>
                 </div>
                 <div class="col-md-6">
-                    <label for="hootsuite_token" class="form-label">Hootsuite Access Token</label>
-                    <input type="text" name="hootsuite_token" id="hootsuite_token" class="form-control">
-                    <div class="form-text">Optional: token used to fetch scheduled posts</div>
-                </div>
-                <div class="col-md-6">
-                    <label for="hootsuite_campaign_tag" class="form-label">Hootsuite Campaign Tag</label>
+                    <label for="hootsuite_campaign_tag" class="form-label">Hootsuite Tag</label>
                     <input type="text" name="hootsuite_campaign_tag" id="hootsuite_campaign_tag" class="form-control">
                 </div>
                 <div class="col-md-6">


### PR DESCRIPTION
## Summary
- drop unused Hootsuite token field on **Add New Store** form
- rename `Hootsuite Campaign Tag` label to match edit form

## Testing
- `php -l admin/stores.php`

------
https://chatgpt.com/codex/tasks/task_e_687a630856788326836e12e00e22e405