### PR TITLE
Fix message date parsing and calendar close icon

### DIFF
--- a/public/calendar.php
+++ b/public/calendar.php
@@ -249,7 +249,7 @@ include __DIR__.'/header.php';
             <div class="modal-content" style="z-index: 9999 !important;">
                 <div class="modal-header" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; border: none; padding: 1.5rem; position: relative;">
                     <div class="modal-title w-100" id="eventModalTitle"></div>
-                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close" style="position: absolute !important; top: 1rem !important; right: 1rem !important; z-index: 99999 !important; background: white !important; opacity: 1 !important; border-radius: 50% !important; width: 2rem !important; height: 2rem !important;"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" style="position: absolute !important; top: 1rem !important; right: 1rem !important; z-index: 99999 !important; background: white !important; opacity: 1 !important; border-radius: 50% !important; width: 2rem !important; height: 2rem !important;"></button>
                 </div>
                 <div class="modal-body" id="eventModalBody" style="padding: 0; overflow: hidden;"></div>
             </div>
@@ -262,7 +262,7 @@ include __DIR__.'/header.php';
             <div class="modal-content" style="z-index: 9999 !important;">
                 <div class="modal-header day-view-header" style="position: relative;">
                     <h5 class="modal-title" id="dayViewTitle"></h5>
-                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close" style="position: absolute !important; top: 1rem !important; right: 1rem !important; z-index: 99999 !important; background: white !important; opacity: 1 !important; border-radius: 50% !important; width: 2rem !important; height: 2rem !important;"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" style="position: absolute !important; top: 1rem !important; right: 1rem !important; z-index: 99999 !important; background: white !important; opacity: 1 !important; border-radius: 50% !important; width: 2rem !important; height: 2rem !important;"></button>
                 </div>
                 <div class="modal-body" id="dayViewBody">
                     <!-- Events will be loaded here -->

--- a/public/messages.php
+++ b/public/messages.php
@@ -16,9 +16,6 @@ if (isset($_GET['load'])) {
     $stmt = $pdo->prepare("SELECT m.id, m.sender, m.message, m.created_at, m.parent_id, m.read_by_store, m.read_by_admin, m.like_by_store, m.like_by_admin, m.love_by_store, m.love_by_admin, p.message AS parent_message, u.filename, u.drive_id FROM store_messages m LEFT JOIN store_messages p ON m.parent_id=p.id LEFT JOIN uploads u ON m.upload_id=u.id WHERE m.store_id = ? ORDER BY m.created_at");
     $stmt->execute([$store_id]);
     $messages = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    foreach ($messages as &$m) {
-        $m['created_at'] = format_ts($m['created_at']);
-    }
     $pdo->prepare("UPDATE store_messages SET read_by_store=1 WHERE store_id=? AND sender='admin' AND read_by_store=0")
         ->execute([$store_id]);
     header('Content-Type: application/json');


### PR DESCRIPTION
## Summary
- remove server-side timestamp formatting so JS can parse message dates
- make close buttons use default icon color

## Testing
- `php -l public/messages.php`
- `php -l public/calendar.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687d9b52e11083269530c0fe43f8efb7