### PR TITLE
Fix dashboard message timestamp and modal close icons

### DIFF
--- a/public/calendar.php
+++ b/public/calendar.php
@@ -249,7 +249,7 @@ include __DIR__.'/header.php';
             <div class="modal-content" style="z-index: 9999 !important;">
                 <div class="modal-header" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; border: none; padding: 1.5rem; position: relative;">
                     <div class="modal-title w-100" id="eventModalTitle"></div>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" style="position: absolute !important; top: 1rem !important; right: 1rem !important; z-index: 99999 !important; background: white !important; opacity: 1 !important; border-radius: 50% !important; width: 2rem !important; height: 2rem !important;"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" style="position: absolute !important; top: 1rem !important; right: 1rem !important; z-index: 99999 !important; background-color: white !important; color: black !important; opacity: 1 !important; border-radius: 50% !important; width: 2rem !important; height: 2rem !important;"></button>
                 </div>
                 <div class="modal-body" id="eventModalBody" style="padding: 0; overflow: hidden;"></div>
             </div>
@@ -262,7 +262,7 @@ include __DIR__.'/header.php';
             <div class="modal-content" style="z-index: 9999 !important;">
                 <div class="modal-header day-view-header" style="position: relative;">
                     <h5 class="modal-title" id="dayViewTitle"></h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" style="position: absolute !important; top: 1rem !important; right: 1rem !important; z-index: 99999 !important; background: white !important; opacity: 1 !important; border-radius: 50% !important; width: 2rem !important; height: 2rem !important;"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" style="position: absolute !important; top: 1rem !important; right: 1rem !important; z-index: 99999 !important; background-color: white !important; color: black !important; opacity: 1 !important; border-radius: 50% !important; width: 2rem !important; height: 2rem !important;"></button>
                 </div>
                 <div class="modal-body" id="dayViewBody">
                     <!-- Events will be loaded here -->
@@ -320,7 +320,8 @@ include __DIR__.'/header.php';
             pointer-events: auto !important;
             padding: 0.5rem !important;
             margin: 0 !important;
-            background: white !important;
+            background-color: white !important;
+            color: black !important;
             border-radius: 50% !important;
             opacity: 1 !important;
             width: 2rem !important;

--- a/public/index.php
+++ b/public/index.php
@@ -1374,7 +1374,9 @@ include __DIR__.'/header.php';
                                     <?php echo $msg['sender'] === 'admin' ? htmlspecialchars($admin_name) : 'You'; ?>
                                 </div>
                                 <div class="message-text"><?php echo nl2br($msg['message']); ?></div>
-                                <div class="message-time"><?php echo format_ts($msg['created_at']); ?></div>
+                                <div class="message-footer">
+                                    <span class="message-time"><?php echo format_ts($msg['created_at']); ?></span>
+                                </div>
                             </div>
                         <?php endforeach; ?>
                     </div>


### PR DESCRIPTION
## Summary
- show proper black X icon in calendar modals
- display message timestamps in dashboard recent messages widget

## Testing
- `php -l public/calendar.php`
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_687d9dcb4f4483269b15cd4e483a0676