### PR TITLE
Fix threads icon missing on calendar

### DIFF
--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -557,6 +557,11 @@ transition: all 0.3s ease;
     border-color:#adb5bd !important;
 }
 
+/* Bootstrap Icons override for Threads */
+.bi-threads::before {
+    content: "\F8D9";
+}
+
 /* Empty State */
 .empty-state {
     text-align: center;


### PR DESCRIPTION
## Summary
- add CSS rule for Threads bootstrap icon

## Testing
- `php -l public/calendar.php`
- `php -l public/inc/css/style.css`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687d9ef13cd48326a4b17a8c8ff4ccb9