### PR TITLE
Fix public side notification updates

### DIFF
--- a/public/footer.php
+++ b/public/footer.php
@@ -1,26 +1,8 @@
 </div>
 <!-- Bootstrap JS from CDN -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
-<script>
-function checkNotifications(){
-    fetch('notifications.php')
-        .then(r=>r.json())
-        .then(d=>{
-            const wrap=document.getElementById('notifyWrap');
-            const count=document.getElementById('notifyCount');
-            if(!wrap) return;
-            if(d.count>0){
-                wrap.style.display='inline-block';
-                count.style.display='inline-block';
-                count.textContent=d.count;
-            }else{
-                wrap.style.display='none';
-            }
-        });
-}
-setInterval(checkNotifications,5000);
-checkNotifications();
-</script>
+
+<!-- Notification polling is handled in header.php -->
 <?php if(isset($extra_js)) echo $extra_js; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove outdated notification script from public footer
- rely on header polling for notification bell

## Testing
- `php -l public/header.php`
- `php -l public/footer.php`
- `php -l admin/footer.php`


------
https://chatgpt.com/codex/tasks/task_e_687da82ab3e083268d89037a0367a7c4