### PR TITLE
Fix notification badge caching

### DIFF
--- a/public/header.php
+++ b/public/header.php
@@ -778,7 +778,7 @@ if (isset($_SESSION['store_id'])) {
 
     // Check notifications periodically
     function checkNotifications() {
-        fetch('notifications.php')
+        fetch('notifications.php?ts=' + Date.now())
             .then(r => r.json())
             .then(d => {
                 const notifyCount = document.getElementById('notifyCount');

--- a/public/notifications.php
+++ b/public/notifications.php
@@ -7,4 +7,7 @@ $count=$pdo->prepare("SELECT COUNT(*) FROM store_messages WHERE store_id=? AND s
 $count->execute([$_SESSION['store_id']]);
 $cnt=$count->fetchColumn();
 header('Content-Type: application/json');
+header('Cache-Control: no-cache, no-store, must-revalidate');
+header('Pragma: no-cache');
+header('Expires: 0');
 echo json_encode(['count'=>(int)$cnt]);


### PR DESCRIPTION
## Summary
- ensure notification badge fetch bypasses caching
- add response headers to avoid caching for notifications

## Testing
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687daafb35ac8326a8eae7780f3d252d