### PR TITLE
Implement thumbnail caching and improve admin dashboard

### DIFF
--- a/admin/chat.php
+++ b/admin/chat.php
@@ -59,7 +59,7 @@ if ($current_store_id) {
 }
 
 if (isset($_GET['load']) && $current_store_id) {
-    $stmt = $pdo->prepare("SELECT m.*, s.name as store_name, u.filename, u.drive_id, u.mime
+    $stmt = $pdo->prepare("SELECT m.*, s.name as store_name, u.filename, u.drive_id, u.mime, u.id AS upload_id
         FROM store_messages m
         JOIN stores s ON m.store_id = s.id
         LEFT JOIN uploads u ON m.upload_id = u.id
@@ -96,7 +96,7 @@ $stores = $pdo->query($stores_query)->fetchAll(PDO::FETCH_ASSOC);
 $messages = [];
 if ($current_store_id) {
     $stmt = $pdo->prepare("
-        SELECT m.*, s.name as store_name, u.filename, u.drive_id, u.mime
+        SELECT m.*, s.name as store_name, u.filename, u.drive_id, u.mime, u.id AS upload_id
         FROM store_messages m
         JOIN stores s ON m.store_id = s.id
         LEFT JOIN uploads u ON m.upload_id = u.id
@@ -976,7 +976,7 @@ include __DIR__.'/header.php';
                                         <?php endif; ?>
                                         <?php if (!empty($msg['filename'])): ?>
                                             <?php if (strpos($msg['mime'], 'image/') === 0): ?>
-                                                <div class="mb-1"><a href="https://drive.google.com/uc?export=view&id=<?php echo $msg['drive_id']; ?>" target="_blank"><img src="https://drive.google.com/uc?export=view&id=<?php echo $msg['drive_id']; ?>" alt="<?php echo htmlspecialchars($msg['filename']); ?>" class="message-img"></a></div>
+                                                <div class="mb-1"><a href="https://drive.google.com/uc?export=view&id=<?php echo $msg['drive_id']; ?>" target="_blank"><img src="thumbnail.php?id=<?php echo $msg['upload_id']; ?>&size=medium" alt="<?php echo htmlspecialchars($msg['filename']); ?>" class="message-img"></a></div>
                                             <?php elseif (strpos($msg['mime'], 'video/') === 0): ?>
                                                 <div class="mb-1"><video src="https://drive.google.com/uc?export=view&id=<?php echo $msg['drive_id']; ?>" controls class="message-video"></video></div>
                                             <?php else: ?>
@@ -1158,7 +1158,7 @@ include __DIR__.'/header.php';
                         }
                         if (m.filename) {
                             if (m.mime && m.mime.startsWith('image/')) {
-                                html += `<div class="mb-1"><a href="https://drive.google.com/uc?export=view&id=${m.drive_id}" target="_blank"><img src="https://drive.google.com/uc?export=view&id=${m.drive_id}" class="message-img" alt="${m.filename}"></a></div>`;
+                                html += `<div class="mb-1"><a href="https://drive.google.com/uc?export=view&id=${m.drive_id}" target="_blank"><img src="thumbnail.php?id=${m.upload_id}&size=medium" class="message-img" alt="${m.filename}"></a></div>`;
                             } else if (m.mime && m.mime.startsWith('video/')) {
                                 html += `<div class="mb-1"><video src="https://drive.google.com/uc?export=view&id=${m.drive_id}" class="message-video" controls></video></div>`;
                             } else {

--- a/admin/delete_upload.php
+++ b/admin/delete_upload.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/auth.php';
+require_login();
+$pdo = get_pdo();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['id'])) {
+    $stmt = $pdo->prepare('DELETE FROM uploads WHERE id = ?');
+    $stmt->execute([$_POST['id']]);
+    header('Content-Type: application/json');
+    echo json_encode(['success' => true]);
+    exit;
+}
+http_response_code(400);
+header('Content-Type: application/json');
+echo json_encode(['error' => 'Invalid request']);

--- a/admin/index.php
+++ b/admin/index.php
@@ -707,8 +707,7 @@ include __DIR__.'/header.php';
                                                    target="_blank" class="btn btn-action btn-action-primary" title="View">
                                                     <i class="bi bi-search"></i>
                                                 </a>
-                                                <form method="post" action="uploads.php" class="d-inline" onsubmit="return confirm('Delete this file?');">
-                                                    <input type="hidden" name="delete_id" value="<?php echo $upload['id']; ?>">
+                                                <form class="d-inline delete-upload-form" data-id="<?php echo $upload['id']; ?>" onsubmit="return false;">
                                                     <button type="submit" class="btn btn-action btn-action-danger" title="Delete">
                                                         <i class="bi bi-trash"></i>
                                                     </button>
@@ -941,5 +940,23 @@ include __DIR__.'/header.php';
             </div>
         </div>
     </div>
+
+    <script>
+    document.querySelectorAll('.delete-upload-form').forEach(form => {
+        form.addEventListener('submit', () => {
+            if(!confirm('Delete this file?')) return;
+            const id = form.dataset.id;
+            const fd = new FormData();
+            fd.append('id', id);
+            fetch('delete_upload.php', {method:'POST', body: fd})
+                .then(r => r.json())
+                .then(res => {
+                    if(res.success){
+                        form.closest('tr').remove();
+                    }
+                });
+        });
+    });
+    </script>
 
 <?php include __DIR__.'/footer.php'; ?>

--- a/admin/thumbnail.php
+++ b/admin/thumbnail.php
@@ -7,8 +7,13 @@ require_once __DIR__.'/../lib/drive.php';
 require_login();
 
 // Get the upload ID
-$id = $_GET['id'] ?? 0;
+$id = intval($_GET['id'] ?? 0);
 $size = $_GET['size'] ?? 'medium';
+
+$cacheDir = __DIR__ . '/../assets/thumbs';
+if (!is_dir($cacheDir)) {
+    mkdir($cacheDir, 0777, true);
+}
 
 // Get upload details
 $pdo = get_pdo();
@@ -23,17 +28,29 @@ if (!$upload) {
     exit;
 }
 
+$isVideo = strpos($upload['mime'], 'video') !== false;
+$ext = $isVideo ? 'svg' : 'jpg';
+$cacheFile = "$cacheDir/{$id}_{$size}.{$ext}";
+
+if (file_exists($cacheFile)) {
+    header('Content-Type: ' . ($isVideo ? 'image/svg+xml' : 'image/jpeg'));
+    readfile($cacheFile);
+    exit;
+}
+
 // Check if it's a video
-if (strpos($upload['mime'], 'video') !== false) {
-    // Return video placeholder
-    header('Content-Type: image/svg+xml');
+if ($isVideo) {
+    // Generate video placeholder and cache it
     $width = $size === 'small' ? 50 : ($size === 'medium' ? 200 : 400);
-    echo '<?xml version="1.0" encoding="UTF-8"?>
+    $svg = '<?xml version="1.0" encoding="UTF-8"?>
     <svg width="'.$width.'" height="'.$width.'" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
         <rect width="100" height="100" fill="#000"/>
         <circle cx="50" cy="50" r="20" fill="none" stroke="#fff" stroke-width="3"/>
         <polygon points="45,40 45,60 60,50" fill="#fff"/>
     </svg>';
+    file_put_contents($cacheFile, $svg);
+    header('Content-Type: image/svg+xml');
+    echo $svg;
     exit;
 }
 
@@ -88,8 +105,9 @@ try {
             curl_close($ch);
 
             if ($httpCode === 200 && $imageData) {
+                file_put_contents($cacheFile, $imageData);
                 header('Content-Type: ' . $contentType);
-                header('Cache-Control: public, max-age=86400'); // Cache for 24 hours
+                header('Cache-Control: public, max-age=86400');
                 echo $imageData;
                 exit;
             }
@@ -100,14 +118,15 @@ try {
     throw new Exception('No thumbnail available');
 
 } catch (Exception $e) {
-    // Return image placeholder
-    header('Content-Type: image/svg+xml');
     $width = $size === 'small' ? 50 : ($size === 'medium' ? 200 : 400);
-    echo '<?xml version="1.0" encoding="UTF-8"?>
+    $svg = '<?xml version="1.0" encoding="UTF-8"?>
     <svg width="'.$width.'" height="'.$width.'" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
         <rect width="100" height="100" fill="#e9ecef"/>
         <path d="M30 70 L30 40 L45 25 L55 25 L70 40 L70 70 Z" fill="#6c757d"/>
         <circle cx="45" cy="45" r="8" fill="#e9ecef"/>
     </svg>';
+    file_put_contents($cacheFile, $svg);
+    header('Content-Type: image/svg+xml');
+    echo $svg;
 }
 ?>


### PR DESCRIPTION
## Summary
- cache thumbnails for uploads to reduce Drive requests
- use cached thumbnails in chat preview
- add AJAX endpoint for deleting uploads
- enable dashboard widget delete button via AJAX

## Testing
- `php -l admin/thumbnail.php`
- `php -l public/thumbnail.php`
- `php -l admin/chat.php`
- `php -l admin/delete_upload.php`
- `php -l admin/index.php`
- `php tests/dbtest.php` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_687eeb32ab988326a0d6a1f0dc77608f