### PR TITLE
Fix chat reactions sync

### DIFF
--- a/admin/chat.php
+++ b/admin/chat.php
@@ -508,6 +508,12 @@ include __DIR__.'/header.php';
         .reaction-button.like.active { color: #0d6efd; }
         .reaction-button.love.active { color: #dc3545; }
 
+        .message-reactions.readonly .reaction-button {
+            cursor: default;
+            pointer-events: none;
+            opacity: 0.8;
+        }
+
         .message-time {
             font-size: 0.75rem;
             opacity: 0.8;
@@ -995,6 +1001,11 @@ include __DIR__.'/header.php';
                                                     <i class="bi bi-heart<?php echo ($msg['love_by_admin']||$msg['love_by_store']) ? '-fill' : ''; ?>"></i>
                                                 </button>
                                             </div>
+                                        <?php elseif ($msg['like_by_store'] || $msg['love_by_store']): ?>
+                                            <div class="message-reactions readonly">
+                                                <span class="reaction-button like <?php echo $msg['like_by_store'] ? 'active' : ''; ?>"><i class="bi bi-hand-thumbs-up<?php echo $msg['like_by_store'] ? '-fill' : ''; ?>"></i></span>
+                                                <span class="reaction-button love <?php echo $msg['love_by_store'] ? 'active' : ''; ?>"><i class="bi bi-heart<?php echo $msg['love_by_store'] ? '-fill' : ''; ?>"></i></span>
+                                            </div>
                                         <?php endif; ?>
                                         <div class="message-time">
                                             <?php echo format_ts($msg['created_at']); ?>
@@ -1034,6 +1045,7 @@ include __DIR__.'/header.php';
         </div>
     </div>
 
+    <script src="../assets/js/chat-common.js"></script>
     <script src="../assets/js/emoji-picker.js"></script>
     <script>
         // Auto-resize textarea
@@ -1178,6 +1190,11 @@ include __DIR__.'/header.php';
                                     `<i class="bi bi-heart${(m.love_by_admin || m.love_by_store)?'-fill':''}"></i>`+
                                     `</button>`+
                                     `</div>`;
+                        } else if (m.like_by_store || m.love_by_store) {
+                            html += `<div class="message-reactions readonly">`+
+                                    `<span class="reaction-button like ${m.like_by_store?'active':''}"><i class="bi bi-hand-thumbs-up${m.like_by_store?'-fill':''}"></i></span>`+
+                                    `<span class="reaction-button love ${m.love_by_store?'active':''}"><i class="bi bi-heart${m.love_by_store?'-fill':''}"></i></span>`+
+                                    `</div>`;
                         }
                         html += `<div class="message-time">${m.created_at}${readIcon}</div></div>`;
                         wrap.innerHTML = html;
@@ -1195,18 +1212,9 @@ include __DIR__.'/header.php';
         }
 
         function initReactions() {
-            document.querySelectorAll('.reaction-button').forEach(btn => {
-                btn.addEventListener('click', () => {
-                    const fd = new FormData();
-                    fd.append('id', btn.dataset.id);
-                    fd.append('type', btn.dataset.type);
-                    fetch('../react.php', { method: 'POST', body: fd })
-                        .then(r => r.json())
-                        .then(() => {
-                            refreshMessages();
-                            if (typeof checkNotifications === 'function') { checkNotifications(); }
-                        });
-                });
+            bindReactionButtons(document, () => {
+                refreshMessages();
+                if (typeof checkNotifications === 'function') { checkNotifications(); }
             });
         }
 

--- a/assets/js/chat-common.js
+++ b/assets/js/chat-common.js
@@ -1,0 +1,50 @@
+// Common chat helper functions
+
+function bindReactionButtons(container, refresh) {
+    container.querySelectorAll('.reaction-button').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const fd = new FormData();
+            fd.append('id', btn.dataset.id);
+            fd.append('type', btn.dataset.type);
+            fetch('../react.php', { method: 'POST', body: fd })
+                .then(r => r.json())
+                .then(() => {
+                    if (typeof refresh === 'function') refresh();
+                });
+        }, { once: true });
+    });
+}
+
+function updateStatsFromMessages(messages, mapping) {
+    const stats = {
+        total: messages.length,
+        admin: 0,
+        store: 0,
+        liked: 0,
+        loved: 0,
+        recent: 0
+    };
+    const weekAgo = Date.now() - 7*24*60*60*1000;
+    messages.forEach(m => {
+        if (m.sender === 'admin') stats.admin++; else stats.store++;
+        if (m.like_by_admin || m.like_by_store) stats.liked++;
+        if (m.love_by_admin || m.love_by_store) stats.loved++;
+        if (new Date(m.created_at).getTime() >= weekAgo) stats.recent++;
+    });
+    if (!mapping) mapping = {
+        total: '[data-stat="total"]',
+        admin: '[data-stat="admin"]',
+        store: '[data-stat="store"]',
+        liked: '[data-stat="liked"]',
+        loved: '[data-stat="loved"]',
+        recent: '[data-stat="recent"]'
+    };
+    Object.keys(stats).forEach(k => {
+        const el = document.querySelector(mapping[k]);
+        if (el) el.textContent = stats[k];
+    });
+}
+
+window.bindReactionButtons = bindReactionButtons;
+window.updateStatsFromMessages = updateStatsFromMessages;
+


### PR DESCRIPTION
## Summary
- add shared chat helpers
- show reaction status across admin and store chats
- refresh message stats dynamically
- include store ID when uploading files

## Testing
- `php -l public/messages.php`
- `php -l admin/chat.php`


------
https://chatgpt.com/codex/tasks/task_e_687eed1e53f48326bf3b307ad9b662fe