### PR TITLE
Fix alert removal and rename messages to chat/broadcasts

### DIFF
--- a/admin/broadcasts.php
+++ b/admin/broadcasts.php
@@ -95,7 +95,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['message'])) {
 if (isset($_GET['delete'])) {
     $stmt = $pdo->prepare('DELETE FROM store_messages WHERE id = ?');
     $stmt->execute([$_GET['delete']]);
-    header('Location: messages.php');
+    header('Location: broadcasts.php');
     exit;
 }
 
@@ -127,7 +127,7 @@ $messages = $stmt->fetchAll(PDO::FETCH_ASSOC);
 $count = $pdo->query("SELECT COUNT(*) $baseQuery")->fetchColumn();
 $total_pages = ceil($count / $per_page);
 
-$active = 'messages';
+$active = 'broadcasts';
 include __DIR__.'/header.php';
 ?>
 

--- a/admin/conversation.php
+++ b/admin/conversation.php
@@ -54,7 +54,7 @@ $s->execute([$store_id]);
 $messages = $s->fetchAll(PDO::FETCH_ASSOC);
 $pdo->prepare("UPDATE store_messages SET read_by_admin=1 WHERE store_id=? AND sender='store' AND read_by_admin=0")->execute([$store_id]);
 
-$active = 'messages';
+$active = 'chat';
 include __DIR__.'/header.php';
 ?>
 <h4>Conversation with <?php echo htmlspecialchars($store['name']); ?></h4>

--- a/admin/edit_message.php
+++ b/admin/edit_message.php
@@ -11,7 +11,7 @@ $stmt->execute([$id]);
 $message = $stmt->fetch(PDO::FETCH_ASSOC);
 
 if (!$message) {
-    header('Location: messages.php');
+    header('Location: broadcasts.php');
     exit;
 }
 
@@ -30,12 +30,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save'])) {
     }
 }
 
-$active = 'messages';
+$active = 'broadcasts';
 include __DIR__.'/header.php';
 ?>
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h4>Edit Broadcast</h4>
-    <a href="messages.php" class="btn btn-sm btn-outline-secondary">Back</a>
+    <a href="broadcasts.php" class="btn btn-sm btn-outline-secondary">Back</a>
 </div>
 <?php foreach ($errors as $e): ?>
     <div class="alert alert-danger alert-dismissible fade show" role="alert">

--- a/admin/footer.php
+++ b/admin/footer.php
@@ -570,7 +570,7 @@
                         break;
                     case 'm':
                         e.preventDefault();
-                        window.location.href = 'messages.php';
+                        window.location.href = 'broadcasts.php';
                         break;
                     case 'c':
                         e.preventDefault();

--- a/admin/header.php
+++ b/admin/header.php
@@ -608,7 +608,7 @@ $version = trim(file_get_contents(__DIR__.'/../VERSION'));
                 <i class="bi bi-cloud-upload"></i>
                 <span>Content</span>
             </a>
-            <a class="nav-link<?php if($active==='messages') echo ' active'; ?>" href="messages.php">
+            <a class="nav-link<?php if($active==='broadcasts') echo ' active'; ?>" href="broadcasts.php">
                 <i class="bi bi-megaphone"></i>
                 <span>Broadcasts</span>
             </a>
@@ -676,7 +676,7 @@ $version = trim(file_get_contents(__DIR__.'/../VERSION'));
                 <i class="bi bi-cloud-upload"></i>
                 <span>Content Review</span>
             </a>
-            <a class="nav-link<?php if($active==='messages') echo ' active'; ?>" href="messages.php">
+            <a class="nav-link<?php if($active==='broadcasts') echo ' active'; ?>" href="broadcasts.php">
                 <i class="bi bi-megaphone"></i>
                 <span>Broadcasts</span>
             </a>

--- a/admin/index.php
+++ b/admin/index.php
@@ -637,7 +637,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </a>
 
-            <a href="messages.php" class="stat-card messages animate__animated animate__fadeInUp" style="animation-delay: 0.3s">
+            <a href="broadcasts.php" class="stat-card messages animate__animated animate__fadeInUp" style="animation-delay: 0.3s">
                 <div class="stat-icon">
                     <i class="bi bi-chat-dots"></i>
                 </div>
@@ -853,7 +853,7 @@ include __DIR__.'/header.php';
                                     </h6>
                                 </div>
                             </a>
-                            <a href="messages.php" class="action-card">
+                            <a href="broadcasts.php" class="action-card">
                                 <div class="action-icon">
                                     <i class="bi bi-chat-dots"></i>
                                 </div>

--- a/config.example.php
+++ b/config.example.php
@@ -18,4 +18,5 @@ return [
         // URL to google_callback.php in your installation
         'redirect_uri' => 'http://yourdomain.com/admin/google_callback.php',
     ],
+    'timezone' => 'America/New_York',
 ];

--- a/lib/config.php
+++ b/lib/config.php
@@ -20,5 +20,10 @@ function get_config(): array {
             throw new Exception('No configuration file found');
         }
     }
+    if (!empty($cfg['timezone'])) {
+        date_default_timezone_set($cfg['timezone']);
+    } else {
+        date_default_timezone_set('America/New_York');
+    }
     return $cfg;
 }

--- a/public/chat.php
+++ b/public/chat.php
@@ -1048,7 +1048,7 @@ include __DIR__.'/header.php';
 
         // Refresh messages
         function refreshMessages() {
-            fetch('messages.php?load=1')
+            fetch('chat.php?load=1')
                 .then(r => r.json())
                 .then(data => {
                     const container = document.getElementById('messages');

--- a/public/header.php
+++ b/public/header.php
@@ -587,9 +587,9 @@ if (isset($_SESSION['store_id'])) {
                     </a>
                 </li>
                 <li class="nav-item-modern">
-                    <a class="nav-link-modern <?php echo $current_page == 'messages.php' ? 'active' : ''; ?>" href="messages.php">
+                    <a class="nav-link-modern <?php echo $current_page == 'chat.php' ? 'active' : ''; ?>" href="chat.php">
                         <i class="bi bi-chat-dots"></i>
-                        <span>Messages</span>
+                        <span>Chat</span>
                         <?php if ($unread_count > 0): ?>
                             <span class="nav-badge"><?php echo $unread_count; ?></span>
                         <?php endif; ?>
@@ -630,7 +630,7 @@ if (isset($_SESSION['store_id'])) {
                             <?php endif; ?>
                         </div>
                         <div class="notification-dropdown-footer">
-                            <a href="messages.php">View all messages</a>
+                            <a href="chat.php">View all messages</a>
                         </div>
                     </div>
                 </div>
@@ -706,9 +706,9 @@ if (isset($_SESSION['store_id'])) {
                         </a>
                     </li>
                     <li class="mobile-menu-item">
-                        <a class="mobile-menu-link <?php echo $current_page == 'messages.php' ? 'active' : ''; ?>" href="messages.php">
+                        <a class="mobile-menu-link <?php echo $current_page == 'chat.php' ? 'active' : ''; ?>" href="chat.php">
                             <i class="bi bi-chat-dots"></i>
-                            Messages
+                            Chat
                             <?php if ($unread_count > 0): ?>
                                 <span class="nav-badge ms-auto"><?php echo $unread_count; ?></span>
                             <?php endif; ?>

--- a/public/marketing.php
+++ b/public/marketing.php
@@ -494,7 +494,7 @@ include __DIR__.'/header.php';
                     <i class="bi bi-graph-up"></i>
                     <h3>Marketing Report Not Set Up</h3>
                     <p>Your marketing analytics dashboard hasn't been configured yet. Contact your admin team to set up your personalized marketing report with real-time insights and performance metrics.</p>
-                    <a href="messages.php" class="contact-admin-btn">
+                    <a href="chat.php" class="contact-admin-btn">
                         <i class="bi bi-chat-dots"></i>
                         Contact Admin
                     </a>

--- a/public/send_message.php
+++ b/public/send_message.php
@@ -27,5 +27,5 @@ $stmt->execute([$_SESSION['store_id'], $message, $parent]);
 if (!empty($_POST['ajax'])) {
     echo json_encode(['success' => true]);
 } else {
-    header('Location: messages.php');
+    header('Location: chat.php');
 }


### PR DESCRIPTION
## Summary
- rename admin/messages.php to broadcasts.php and update routes
- rename public/messages.php to chat.php and update references
- ensure app timezone defaults to Eastern Time
- clean up alert dismissal logic so notifications stay closed
- update menus and links for new chat/broadcasts names

## Testing
- `php -l admin/broadcasts.php`
- `php -l admin/conversation.php`
- `php -l admin/edit_message.php`
- `php -l admin/footer.php`
- `php -l admin/header.php`
- `php -l admin/index.php`
- `php -l config.example.php`
- `php -l lib/config.php`
- `php -l public/chat.php`
- `php -l public/header.php`
- `php -l public/index.php`
- `php -l public/marketing.php`
- `php -l public/send_message.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687ef02039c48326a0da295a0b81bdc4