### PR TITLE
Move inline styles to shared CSS

### DIFF
--- a/admin/broadcasts.php
+++ b/admin/broadcasts.php
@@ -610,7 +610,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card success animate__animated animate__fadeInUp" style="animation-delay: 0.1s">
+            <div class="stat-card success animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-globe"></i>
                 </div>
@@ -619,7 +619,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card warning animate__animated animate__fadeInUp" style="animation-delay: 0.2s">
+            <div class="stat-card warning animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-shop"></i>
                 </div>
@@ -628,7 +628,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card info animate__animated animate__fadeInUp" style="animation-delay: 0.3s">
+            <div class="stat-card info animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-calendar-week"></i>
                 </div>
@@ -637,7 +637,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card danger animate__animated animate__fadeInUp" style="animation-delay: 0.4s">
+            <div class="stat-card danger animate__animated animate__fadeInUp delay-40">
                 <div class="stat-icon">
                     <i class="bi bi-calendar-month"></i>
                 </div>
@@ -646,7 +646,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card secondary animate__animated animate__fadeInUp" style="animation-delay: 0.5s">
+            <div class="stat-card secondary animate__animated animate__fadeInUp delay-50">
                 <div class="stat-icon">
                     <i class="bi bi-activity"></i>
                 </div>
@@ -659,7 +659,7 @@ include __DIR__.'/header.php';
         <!-- Content Grid -->
         <div class="content-grid">
             <!-- Broadcast Form -->
-            <div class="broadcast-card animate__animated animate__fadeIn" style="animation-delay: 0.6s">
+            <div class="broadcast-card animate__animated animate__fadeIn delay-60">
                 <div class="card-header-modern">
                     <h5 class="card-title-modern">
                         <i class="bi bi-send"></i>
@@ -717,7 +717,7 @@ include __DIR__.'/header.php';
             </div>
 
             <!-- Messages List -->
-            <div class="messages-card animate__animated animate__fadeIn" style="animation-delay: 0.7s">
+            <div class="messages-card animate__animated animate__fadeIn delay-70">
                 <div class="card-header-modern">
                     <h5 class="card-title-modern">
                         <i class="bi bi-chat-square-text"></i>

--- a/admin/chat.php
+++ b/admin/chat.php
@@ -834,7 +834,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card warning animate__animated animate__fadeInUp" style="animation-delay: 0.1s">
+            <div class="stat-card warning animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-envelope-fill"></i>
                 </div>
@@ -843,7 +843,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card success animate__animated animate__fadeInUp" style="animation-delay: 0.2s">
+            <div class="stat-card success animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-calendar-check-fill"></i>
                 </div>
@@ -852,7 +852,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card info animate__animated animate__fadeInUp" style="animation-delay: 0.3s">
+            <div class="stat-card info animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-activity"></i>
                 </div>
@@ -863,7 +863,7 @@ include __DIR__.'/header.php';
         </div>
 
         <!-- Chat Interface -->
-        <div class="chat-container animate__animated animate__fadeIn" style="animation-delay: 0.4s">
+        <div class="chat-container animate__animated animate__fadeIn delay-40">
             <!-- Stores List -->
             <div class="stores-panel">
                 <div class="panel-header">
@@ -876,7 +876,7 @@ include __DIR__.'/header.php';
                     <?php if (empty($stores)): ?>
                         <div class="no-stores">
                             <div>
-                                <i class="bi bi-shop" style="font-size: 2rem; opacity: 0.3; margin-bottom: 0.5rem;"></i>
+                                <i class="bi bi-shop empty-icon"></i>
                                 <p>No stores available</p>
                             </div>
                         </div>
@@ -888,7 +888,7 @@ include __DIR__.'/header.php';
                                data-name="<?php echo htmlspecialchars($store['name'], ENT_QUOTES); ?>"
                                data-email="<?php echo htmlspecialchars($store['admin_email'] ?? '', ENT_QUOTES); ?>"
                                data-phone="<?php echo htmlspecialchars($store['phone'] ?? '', ENT_QUOTES); ?>">
-                                <div class="store-avatar" style="position: relative;">
+                                <div class="store-avatar position-relative">
                                     <?php echo strtoupper(substr($store['name'], 0, 2)); ?>
                                     <?php if ($store['unread_count'] > 0): ?>
                                         <div class="online-indicator"></div>
@@ -956,7 +956,7 @@ include __DIR__.'/header.php';
                         <div class="chat-actions">
                             <form method="post" class="d-inline">
                                 <input type="hidden" name="store_id" value="<?php echo $current_store_id; ?>">
-                                <button type="submit" name="mark_read" class="btn btn-chat-action btn-mark-read"<?php echo $current_unread ? '' : ' style="display:none;"'; ?>>
+                                <button type="submit" name="mark_read" class="btn btn-chat-action btn-mark-read"<?php echo $current_unread ? '' : ' d-none'; ?>>
                                     <i class="bi bi-check-all me-1"></i>Mark Read
                                 </button>
                             </form>

--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -568,7 +568,7 @@ include __DIR__.'/header.php';
 
         <!-- Store Details Form -->
         <form method="post">
-            <div class="form-card animate__animated animate__fadeIn" style="animation-delay: 0.1s">
+            <div class="form-card animate__animated animate__fadeIn delay-10">
                 <div class="card-header-modern">
                     <h5 class="card-title-modern">
                         <i class="bi bi-info-circle"></i>
@@ -652,7 +652,7 @@ include __DIR__.'/header.php';
                 </div>
             </div>
 
-            <div class="form-card animate__animated animate__fadeIn" style="animation-delay: 0.2s">
+            <div class="form-card animate__animated animate__fadeIn delay-20">
                 <div class="card-header-modern">
                     <h5 class="card-title-modern">
                         <i class="bi bi-gear"></i>
@@ -695,7 +695,7 @@ include __DIR__.'/header.php';
         </form>
 
         <!-- Store Users -->
-        <div class="form-card animate__animated animate__fadeIn" style="animation-delay: 0.3s">
+        <div class="form-card animate__animated animate__fadeIn delay-30">
             <div class="card-header-modern">
                 <h5 class="card-title-modern">
                     <i class="bi bi-people"></i>

--- a/admin/edit_store_user.php
+++ b/admin/edit_store_user.php
@@ -488,7 +488,7 @@ include __DIR__.'/header.php';
         <div class="row">
             <div class="col-lg-4">
                 <!-- User Profile Card -->
-                <div class="profile-card animate__animated animate__fadeIn" style="animation-delay: 0.1s">
+                <div class="profile-card animate__animated animate__fadeIn delay-10">
                     <div class="profile-header">
                         <div class="profile-avatar">
                             <?php
@@ -557,7 +557,7 @@ include __DIR__.'/header.php';
 
             <div class="col-lg-8">
                 <!-- Edit Form -->
-                <div class="form-card animate__animated animate__fadeIn" style="animation-delay: 0.2s">
+                <div class="form-card animate__animated animate__fadeIn delay-20">
                     <div class="card-header-modern">
                         <h5 class="card-title-modern">
                             <i class="bi bi-pencil-square"></i>

--- a/admin/edit_user.php
+++ b/admin/edit_user.php
@@ -510,7 +510,7 @@ include __DIR__.'/header.php';
         <div class="row">
             <div class="col-lg-4">
                 <!-- User Profile Card -->
-                <div class="profile-card animate__animated animate__fadeIn" style="animation-delay: 0.1s">
+                <div class="profile-card animate__animated animate__fadeIn delay-10">
                     <div class="profile-header">
                         <div class="profile-avatar">
                             <?php
@@ -586,7 +586,7 @@ include __DIR__.'/header.php';
 
             <div class="col-lg-8">
                 <!-- Edit Form -->
-                <div class="form-card animate__animated animate__fadeIn" style="animation-delay: 0.2s">
+                <div class="form-card animate__animated animate__fadeIn delay-20">
                     <div class="card-header-modern">
                         <h5 class="card-title-modern">
                             <i class="bi bi-pencil-square"></i>

--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -78,6 +78,19 @@ table th, table td {
 .btn-send { background-color: #18bc9c; border-color: #18bc9c; color: #fff; }
 .btn-send:hover { background-color: #17a689; border-color: #17a689; color: #fff; }
 .chat-form textarea { height: 38px; resize: none; }
+
+/* Animation delay utility classes */
+.delay-5 { animation-delay: 0.05s !important; }
+.delay-10 { animation-delay: 0.1s !important; }
+.delay-20 { animation-delay: 0.2s !important; }
+.delay-30 { animation-delay: 0.3s !important; }
+.delay-40 { animation-delay: 0.4s !important; }
+.delay-50 { animation-delay: 0.5s !important; }
+.delay-60 { animation-delay: 0.6s !important; }
+.delay-70 { animation-delay: 0.7s !important; }
+.delay-80 { animation-delay: 0.8s !important; }
+.delay-90 { animation-delay: 0.9s !important; }
+.delay-100 { animation-delay: 1s !important; }
 .reply-preview { font-size: 0.8rem; color: #666; border-left: 2px solid #ccc; padding-left:4px; margin-bottom:4px; }
 #messages .bubble small { color:#999; display:block; margin-top:2px; }
 .bubble-container{position:relative;display:inline-block;}
@@ -88,6 +101,9 @@ table th, table td {
 .mention-box div:hover{background:#f0f0f0;}
 .sidebar-locked .offcanvas-end{transform:none!important;visibility:visible!important;}
 .sidebar-locked .offcanvas-backdrop{display:none;}
+
+/* Utility icon for empty states */
+.empty-icon { font-size: 2rem; opacity: 0.3; margin-bottom: 0.5rem; }
 
 /* Chat sidebar toggle */
 #sidebarTab{

--- a/admin/index.php
+++ b/admin/index.php
@@ -614,7 +614,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </a>
 
-            <a href="uploads.php" class="stat-card uploads animate__animated animate__fadeInUp" style="animation-delay: 0.1s">
+            <a href="uploads.php" class="stat-card uploads animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-cloud-upload"></i>
                 </div>
@@ -623,7 +623,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </a>
 
-            <a href="articles.php" class="stat-card articles animate__animated animate__fadeInUp" style="animation-delay: 0.2s">
+            <a href="articles.php" class="stat-card articles animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-file-text"></i>
                 </div>
@@ -637,7 +637,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </a>
 
-            <a href="broadcasts.php" class="stat-card messages animate__animated animate__fadeInUp" style="animation-delay: 0.3s">
+            <a href="broadcasts.php" class="stat-card messages animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-chat-dots"></i>
                 </div>
@@ -646,7 +646,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </a>
 
-            <a href="stores.php" class="stat-card users animate__animated animate__fadeInUp" style="animation-delay: 0.4s">
+            <a href="stores.php" class="stat-card users animate__animated animate__fadeInUp delay-40">
                 <div class="stat-icon">
                     <i class="bi bi-people"></i>
                 </div>
@@ -660,7 +660,7 @@ include __DIR__.'/header.php';
         <div class="content-grid">
             <div>
                 <!-- Recent Uploads -->
-                <div class="content-card mb-4 animate__animated animate__fadeIn" style="animation-delay: 0.5s">
+                <div class="content-card mb-4 animate__animated animate__fadeIn delay-50">
                     <div class="card-header-modern">
                         <h5 class="card-title-modern">
                             <i class="bi bi-clock-history"></i>
@@ -729,7 +729,7 @@ include __DIR__.'/header.php';
 
                 <!-- Recent Articles -->
                 <?php if (!empty($recent_articles)): ?>
-                    <div class="content-card mb-4 animate__animated animate__fadeIn" style="animation-delay: 0.6s">
+                    <div class="content-card mb-4 animate__animated animate__fadeIn delay-60">
                         <div class="card-header-modern">
                             <h5 class="card-title-modern">
                                 <i class="bi bi-file-text"></i>
@@ -787,7 +787,7 @@ include __DIR__.'/header.php';
                 <?php endif; ?>
 
                 <!-- Recent Broadcasts -->
-                <div class="content-card animate__animated animate__fadeIn" style="animation-delay: 0.7s">
+                <div class="content-card animate__animated animate__fadeIn delay-70">
                     <div class="card-header-modern">
                         <h5 class="card-title-modern">
                             <i class="bi bi-megaphone"></i>
@@ -815,7 +815,7 @@ include __DIR__.'/header.php';
 
             <div>
                 <!-- Quick Actions -->
-                <div class="content-card mb-4 animate__animated animate__fadeIn" style="animation-delay: 0.8s">
+                <div class="content-card mb-4 animate__animated animate__fadeIn delay-80">
                     <div class="card-header-modern">
                         <h5 class="card-title-modern">
                             <i class="bi bi-lightning-charge"></i>
@@ -874,7 +874,7 @@ include __DIR__.'/header.php';
                 </div>
 
                 <!-- Quick Broadcast -->
-                <div class="content-card mb-4 animate__animated animate__fadeIn" style="animation-delay: 0.9s">
+                <div class="content-card mb-4 animate__animated animate__fadeIn delay-90">
                     <div class="card-header-modern">
                         <h5 class="card-title-modern">
                             <i class="bi bi-send"></i>
@@ -914,7 +914,7 @@ include __DIR__.'/header.php';
                 </div>
 
                 <!-- This Week Activity -->
-                <div class="content-card animate__animated animate__fadeIn" style="animation-delay: 1s">
+                <div class="content-card animate__animated animate__fadeIn delay-100">
                     <div class="card-header-modern">
                         <h5 class="card-title-modern">
                             <i class="bi bi-graph-up"></i>

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -759,7 +759,7 @@ include __DIR__.'/header.php';
         </div>
 
         <!-- System Information Card -->
-        <div class="system-info-card animate__animated animate__fadeIn" style="animation-delay: 0.1s">
+        <div class="system-info-card animate__animated animate__fadeIn delay-10">
             <h5 class="mb-0">
                 <i class="bi bi-speedometer2 me-2"></i>
                 MediaHub Admin System
@@ -839,7 +839,7 @@ include __DIR__.'/header.php';
 
         <form method="post" enctype="multipart/form-data">
             <!-- Modern Navigation Tabs -->
-            <ul class="nav-tabs-modern animate__animated animate__fadeIn" style="animation-delay: 0.2s" id="settingsTabs" role="tablist">
+            <ul class="nav-tabs-modern animate__animated animate__fadeIn delay-20" id="settingsTabs" role="tablist">
                 <li class="nav-item" role="presentation">
                     <button class="nav-link<?php if($active_tab==='general') echo ' active'; ?>" id="general-tab" data-bs-toggle="tab" data-bs-target="#general" type="button" role="tab">
                         <i class="bi bi-gear"></i> General
@@ -877,7 +877,7 @@ include __DIR__.'/header.php';
                 <div class="tab-pane fade<?php if($active_tab==='general') echo ' show active'; ?>" id="general" role="tabpanel">
                     <div class="settings-grid settings-grid-2">
                         <!-- Google Drive Settings -->
-                        <div class="settings-card animate__animated animate__fadeIn" style="animation-delay: 0.3s">
+                        <div class="settings-card animate__animated animate__fadeIn delay-30">
                             <div class="card-header-modern">
                                 <h5 class="card-title-modern">
                                     <i class="bi bi-google"></i>
@@ -915,7 +915,7 @@ include __DIR__.'/header.php';
                         </div>
 
                         <!-- Email Settings -->
-                        <div class="settings-card animate__animated animate__fadeIn" style="animation-delay: 0.4s">
+                        <div class="settings-card animate__animated animate__fadeIn delay-40">
                             <div class="card-header-modern">
                                 <h5 class="card-title-modern">
                                     <i class="bi bi-envelope"></i>
@@ -949,7 +949,7 @@ include __DIR__.'/header.php';
                     </div>
 
                     <!-- Article Settings -->
-                    <div class="settings-card animate__animated animate__fadeIn" style="animation-delay: 0.5s">
+                    <div class="settings-card animate__animated animate__fadeIn delay-50">
                         <div class="card-header-modern">
                             <h5 class="card-title-modern">
                                 <i class="bi bi-file-text"></i>
@@ -970,7 +970,7 @@ include __DIR__.'/header.php';
                     </div>
 
                     <!-- Location Information -->
-                    <div class="settings-card animate__animated animate__fadeIn" style="animation-delay: 0.6s">
+                    <div class="settings-card animate__animated animate__fadeIn delay-60">
                         <div class="card-header-modern">
                             <h5 class="card-title-modern">
                                 <i class="bi bi-geo-alt"></i>
@@ -1016,7 +1016,7 @@ include __DIR__.'/header.php';
 
                 <!-- Dripley CRM Tab -->
                 <div class="tab-pane fade<?php if($active_tab==='dripley') echo ' show active'; ?>" id="dripley" role="tabpanel">
-                    <div class="settings-card animate__animated animate__fadeIn" style="animation-delay: 0.3s">
+                    <div class="settings-card animate__animated animate__fadeIn delay-30">
                         <div class="card-header-modern">
                             <h5 class="card-title-modern">
                                 <i class="bi bi-people"></i>
@@ -1094,7 +1094,7 @@ include __DIR__.'/header.php';
 
                 <!-- Email Subjects Tab -->
                 <div class="tab-pane fade<?php if($active_tab==='subjects') echo ' show active'; ?>" id="subjects" role="tabpanel">
-                    <div class="settings-card animate__animated animate__fadeIn" style="animation-delay: 0.3s">
+                    <div class="settings-card animate__animated animate__fadeIn delay-30">
                         <div class="card-header-modern">
                             <h5 class="card-title-modern">
                                 <i class="bi bi-cloud-upload"></i>
@@ -1126,7 +1126,7 @@ include __DIR__.'/header.php';
                         </div>
                     </div>
 
-                    <div class="settings-card animate__animated animate__fadeIn" style="animation-delay: 0.4s">
+                    <div class="settings-card animate__animated animate__fadeIn delay-40">
                         <div class="card-header-modern">
                             <h5 class="card-title-modern">
                                 <i class="bi bi-file-text"></i>
@@ -1161,7 +1161,7 @@ include __DIR__.'/header.php';
 
                 <!-- Statuses Tab -->
                 <div class="tab-pane fade<?php if($active_tab==='statuses') echo ' show active'; ?>" id="statuses" role="tabpanel">
-                    <div class="settings-card animate__animated animate__fadeIn" style="animation-delay: 0.3s">
+                    <div class="settings-card animate__animated animate__fadeIn delay-30">
                         <div class="card-header-modern">
                             <h5 class="card-title-modern">
                                 <i class="bi bi-tags"></i>
@@ -1216,7 +1216,7 @@ include __DIR__.'/header.php';
 
                 <!-- Calendar Tab -->
                 <div class="tab-pane fade<?php if($active_tab==='calendar') echo ' show active'; ?>" id="calendar" role="tabpanel">
-                    <div class="settings-card animate__animated animate__fadeIn" style="animation-delay: 0.3s">
+                    <div class="settings-card animate__animated animate__fadeIn delay-30">
                         <div class="card-header-modern">
                             <h5 class="card-title-modern">
                                 <i class="bi bi-calendar"></i>
@@ -1258,7 +1258,7 @@ include __DIR__.'/header.php';
                         </div>
                     </div>
 
-                    <div class="settings-card animate__animated animate__fadeIn" style="animation-delay: 0.4s">
+                    <div class="settings-card animate__animated animate__fadeIn delay-40">
                         <div class="card-header-modern">
                             <h5 class="card-title-modern">
                                 <i class="bi bi-share"></i>
@@ -1314,7 +1314,7 @@ include __DIR__.'/header.php';
 
                 <!-- Reset Tab -->
                 <div class="tab-pane fade<?php if($active_tab==='reset') echo ' show active'; ?>" id="reset" role="tabpanel">
-                    <div class="settings-card animate__animated animate__fadeIn" style="animation-delay: 0.3s">
+                    <div class="settings-card animate__animated animate__fadeIn delay-30">
                         <div class="card-header-modern">
                             <h5 class="card-title-modern">
                                 <i class="bi bi-exclamation-triangle"></i>

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -510,7 +510,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card success animate__animated animate__fadeInUp" style="animation-delay: 0.1s">
+            <div class="stat-card success animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-cloud-upload"></i>
                 </div>
@@ -519,7 +519,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card warning animate__animated animate__fadeInUp" style="animation-delay: 0.2s">
+            <div class="stat-card warning animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-chat-dots"></i>
                 </div>
@@ -528,7 +528,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card info animate__animated animate__fadeInUp" style="animation-delay: 0.3s">
+            <div class="stat-card info animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-activity"></i>
                 </div>
@@ -539,7 +539,7 @@ include __DIR__.'/header.php';
         </div>
 
         <!-- Stores Table -->
-        <div class="stores-card animate__animated animate__fadeIn" style="animation-delay: 0.4s">
+        <div class="stores-card animate__animated animate__fadeIn delay-40">
             <div class="card-header-modern">
                 <h5 class="card-title-modern">
                     <i class="bi bi-list-ul"></i>
@@ -632,7 +632,7 @@ include __DIR__.'/header.php';
         </div>
 
         <!-- Add New Store -->
-        <div class="add-store-card animate__animated animate__fadeIn" style="animation-delay: 0.5s">
+        <div class="add-store-card animate__animated animate__fadeIn delay-50">
             <div class="card-header-modern">
                 <h5 class="card-title-modern">
                     <i class="bi bi-plus-circle"></i>

--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -636,7 +636,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card success animate__animated animate__fadeInUp" style="animation-delay: 0.1s">
+            <div class="stat-card success animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-calendar-week-fill"></i>
                 </div>
@@ -645,7 +645,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card warning animate__animated animate__fadeInUp" style="animation-delay: 0.2s">
+            <div class="stat-card warning animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-calendar-check-fill"></i>
                 </div>
@@ -654,7 +654,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card info animate__animated animate__fadeInUp" style="animation-delay: 0.3s">
+            <div class="stat-card info animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-image-fill"></i>
                 </div>
@@ -663,7 +663,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card danger animate__animated animate__fadeInUp" style="animation-delay: 0.4s">
+            <div class="stat-card danger animate__animated animate__fadeInUp delay-40">
                 <div class="stat-icon">
                     <i class="bi bi-camera-video-fill"></i>
                 </div>
@@ -672,7 +672,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card secondary animate__animated animate__fadeInUp" style="animation-delay: 0.5s">
+            <div class="stat-card secondary animate__animated animate__fadeInUp delay-50">
                 <div class="stat-icon">
                     <i class="bi bi-clock-history"></i>
                 </div>
@@ -683,7 +683,7 @@ include __DIR__.'/header.php';
         </div>
 
         <!-- Filters -->
-        <div class="filter-card animate__animated animate__fadeIn" style="animation-delay: 0.6s">
+        <div class="filter-card animate__animated animate__fadeIn delay-60">
             <h5 class="filter-title">
                 <i class="bi bi-funnel"></i> Filters
             </h5>
@@ -745,7 +745,7 @@ include __DIR__.'/header.php';
         </div>
 
         <!-- Uploads Table -->
-        <div class="uploads-card animate__animated animate__fadeIn" style="animation-delay: 0.7s">
+        <div class="uploads-card animate__animated animate__fadeIn delay-70">
             <div class="card-header-modern">
                 <h5 class="card-title-modern">
                     <i class="bi bi-cloud-upload"></i>

--- a/admin/users.php
+++ b/admin/users.php
@@ -496,7 +496,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card success animate__animated animate__fadeInUp" style="animation-delay: 0.1s">
+            <div class="stat-card success animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-person-plus-fill"></i>
                 </div>
@@ -505,7 +505,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card warning animate__animated animate__fadeInUp" style="animation-delay: 0.2s">
+            <div class="stat-card warning animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-person-check-fill"></i>
                 </div>
@@ -516,7 +516,7 @@ include __DIR__.'/header.php';
         </div>
 
         <!-- Users Table -->
-        <div class="users-card animate__animated animate__fadeIn" style="animation-delay: 0.3s">
+        <div class="users-card animate__animated animate__fadeIn delay-30">
             <div class="card-header-modern">
                 <h5 class="card-title-modern">
                     <i class="bi bi-list-ul"></i>
@@ -597,7 +597,7 @@ include __DIR__.'/header.php';
         </div>
 
         <!-- Add New User -->
-        <div class="add-user-card animate__animated animate__fadeIn" style="animation-delay: 0.4s">
+        <div class="add-user-card animate__animated animate__fadeIn delay-40">
             <div class="card-header-modern">
                 <h5 class="card-title-modern">
                     <i class="bi bi-person-plus"></i>

--- a/public/articles.php
+++ b/public/articles.php
@@ -1148,7 +1148,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card pending animate__animated animate__fadeInUp" style="animation-delay: 0.1s">
+            <div class="stat-card pending animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-clock-fill"></i>
                 </div>
@@ -1157,7 +1157,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card approved animate__animated animate__fadeInUp" style="animation-delay: 0.2s">
+            <div class="stat-card approved animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-check-circle-fill"></i>
                 </div>
@@ -1166,7 +1166,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card rejected animate__animated animate__fadeInUp" style="animation-delay: 0.3s">
+            <div class="stat-card rejected animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-x-circle-fill"></i>
                 </div>
@@ -1175,7 +1175,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card drafts animate__animated animate__fadeInUp" style="animation-delay: 0.4s">
+            <div class="stat-card drafts animate__animated animate__fadeInUp delay-40">
                 <div class="stat-icon">
                     <i class="bi bi-file-earmark-text"></i>
                 </div>
@@ -1184,7 +1184,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card rate animate__animated animate__fadeInUp" style="animation-delay: 0.5s">
+            <div class="stat-card rate animate__animated animate__fadeInUp delay-50">
                 <div class="stat-icon">
                     <i class="bi bi-graph-up-arrow"></i>
                 </div>
@@ -1195,7 +1195,7 @@ include __DIR__.'/header.php';
         </div>
 
         <!-- Tabs -->
-        <div class="modern-tabs animate__animated animate__fadeIn" style="animation-delay: 0.6s">
+        <div class="modern-tabs animate__animated animate__fadeIn delay-60">
             <a class="tab-link <?php echo $tab === 'submit' ? 'active' : ''; ?>" href="?tab=submit">
                 <i class="bi bi-pencil-square"></i>
                 Submit Article
@@ -1211,7 +1211,7 @@ include __DIR__.'/header.php';
 
         <?php if ($tab === 'submit'): ?>
             <!-- Submit Article Tab -->
-            <div class="article-form-section animate__animated animate__fadeIn" style="animation-delay: 0.7s">
+            <div class="article-form-section animate__animated animate__fadeIn delay-70">
                 <div class="form-header">
                     <h3 class="form-title">Submit New Article</h3>
                     <p class="form-description">Share your story, news, or press release with us</p>
@@ -1345,7 +1345,7 @@ include __DIR__.'/header.php';
                 </div>
             <?php else: ?>
                 <!-- Filters Section -->
-                <div class="filters-section animate__animated animate__fadeIn" style="animation-delay: 0.7s">
+                <div class="filters-section animate__animated animate__fadeIn delay-70">
                     <div class="filters-row">
                         <div class="filter-group">
                             <span class="filter-label">Status:</span>

--- a/public/calendar.php
+++ b/public/calendar.php
@@ -198,7 +198,7 @@ include __DIR__.'/header.php';
                     <div class="stat-bg"></div>
                 </div>
 
-                <div class="stat-card upcoming-posts animate__animated animate__fadeInUp" style="animation-delay: 0.1s">
+                <div class="stat-card upcoming-posts animate__animated animate__fadeInUp delay-10">
                     <div class="stat-icon">
                         <i class="bi bi-clock-history"></i>
                     </div>
@@ -237,7 +237,7 @@ include __DIR__.'/header.php';
             </div>
 
             <!-- Calendar -->
-            <div class="calendar-wrapper animate__animated animate__fadeIn" style="animation-delay: 0.3s">
+            <div class="calendar-wrapper animate__animated animate__fadeIn delay-30">
                 <div id="calendar"></div>
             </div>
         <?php endif; ?>

--- a/public/chat.php
+++ b/public/chat.php
@@ -784,7 +784,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card admin-messages animate__animated animate__fadeInUp" style="animation-delay: 0.1s">
+            <div class="stat-card admin-messages animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-person-badge-fill"></i>
                 </div>
@@ -793,7 +793,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card your-messages animate__animated animate__fadeInUp" style="animation-delay: 0.2s">
+            <div class="stat-card your-messages animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-person-fill"></i>
                 </div>
@@ -802,7 +802,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card liked animate__animated animate__fadeInUp" style="animation-delay: 0.3s">
+            <div class="stat-card liked animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-hand-thumbs-up-fill"></i>
                 </div>
@@ -811,7 +811,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card loved animate__animated animate__fadeInUp" style="animation-delay: 0.4s">
+            <div class="stat-card loved animate__animated animate__fadeInUp delay-40">
                 <div class="stat-icon">
                     <i class="bi bi-heart-fill"></i>
                 </div>
@@ -820,7 +820,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card recent animate__animated animate__fadeInUp" style="animation-delay: 0.5s">
+            <div class="stat-card recent animate__animated animate__fadeInUp delay-50">
                 <div class="stat-icon">
                     <i class="bi bi-clock-fill"></i>
                 </div>
@@ -831,7 +831,7 @@ include __DIR__.'/header.php';
         </div>
 
         <!-- Chat Container -->
-        <div class="chat-wrapper animate__animated animate__fadeIn" style="animation-delay: 0.6s">
+        <div class="chat-wrapper animate__animated animate__fadeIn delay-60">
             <div class="chat-header">
                 <div class="chat-avatar">
                     <i class="bi bi-building"></i>

--- a/public/history.php
+++ b/public/history.php
@@ -704,7 +704,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card total-size animate__animated animate__fadeInUp" style="animation-delay: 0.1s">
+            <div class="stat-card total-size animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-hdd-fill"></i>
                 </div>
@@ -713,7 +713,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card images animate__animated animate__fadeInUp" style="animation-delay: 0.2s">
+            <div class="stat-card images animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-image-fill"></i>
                 </div>
@@ -722,7 +722,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card videos animate__animated animate__fadeInUp" style="animation-delay: 0.3s">
+            <div class="stat-card videos animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-camera-video-fill"></i>
                 </div>
@@ -731,7 +731,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card recent animate__animated animate__fadeInUp" style="animation-delay: 0.4s">
+            <div class="stat-card recent animate__animated animate__fadeInUp delay-40">
                 <div class="stat-icon">
                     <i class="bi bi-clock-fill"></i>
                 </div>
@@ -742,7 +742,7 @@ include __DIR__.'/header.php';
         </div>
 
         <!-- Filters Section -->
-        <div class="filters-section animate__animated animate__fadeIn" style="animation-delay: 0.5s">
+        <div class="filters-section animate__animated animate__fadeIn delay-50">
             <div class="filters-row">
                 <div class="filter-group">
                     <span class="filter-label">Type:</span>

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -2516,8 +2516,30 @@ table th, table td {
         flex-direction: column;
     }
 
-    .btn-modern {
-        width: 100%;
-        justify-content: center;
-    }
+.btn-modern {
+    width: 100%;
+    justify-content: center;
+}
+
+/* Utility styles */
+.textarea-rounded {
+    border-radius: 12px;
+    border: 2px solid #e0e0e0;
+}
+.rounded-8 {
+    border-radius: 8px;
+}
+
+/* Animation delay utility classes */
+.delay-5 { animation-delay: 0.05s !important; }
+.delay-10 { animation-delay: 0.1s !important; }
+.delay-20 { animation-delay: 0.2s !important; }
+.delay-30 { animation-delay: 0.3s !important; }
+.delay-40 { animation-delay: 0.4s !important; }
+.delay-50 { animation-delay: 0.5s !important; }
+.delay-60 { animation-delay: 0.6s !important; }
+.delay-70 { animation-delay: 0.7s !important; }
+.delay-80 { animation-delay: 0.8s !important; }
+.delay-90 { animation-delay: 0.9s !important; }
+.delay-100 { animation-delay: 1s !important; }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -1246,7 +1246,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card success animate__animated animate__fadeInUp" style="animation-delay: 0.1s">
+            <div class="stat-card success animate__animated animate__fadeInUp delay-10">
                 <div class="stat-icon">
                     <i class="bi bi-calendar-week-fill"></i>
                 </div>
@@ -1260,7 +1260,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card warning animate__animated animate__fadeInUp" style="animation-delay: 0.2s">
+            <div class="stat-card warning animate__animated animate__fadeInUp delay-20">
                 <div class="stat-icon">
                     <i class="bi bi-image-fill"></i>
                 </div>
@@ -1269,7 +1269,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card info animate__animated animate__fadeInUp" style="animation-delay: 0.3s">
+            <div class="stat-card info animate__animated animate__fadeInUp delay-30">
                 <div class="stat-icon">
                     <i class="bi bi-camera-video-fill"></i>
                 </div>
@@ -1278,7 +1278,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card danger animate__animated animate__fadeInUp" style="animation-delay: 0.4s">
+            <div class="stat-card danger animate__animated animate__fadeInUp delay-40">
                 <div class="stat-icon">
                     <i class="bi bi-calendar-event-fill"></i>
                 </div>
@@ -1287,7 +1287,7 @@ include __DIR__.'/header.php';
                 <div class="stat-bg"></div>
             </div>
 
-            <div class="stat-card secondary animate__animated animate__fadeInUp" style="animation-delay: 0.5s">
+            <div class="stat-card secondary animate__animated animate__fadeInUp delay-50">
                 <div class="stat-icon">
                     <i class="bi bi-chat-dots-fill"></i>
                 </div>
@@ -1306,7 +1306,7 @@ include __DIR__.'/header.php';
         <div class="content-grid">
             <div class="left-column">
             <!-- Upload Section -->
-            <div class="upload-section animate__animated animate__fadeIn" style="animation-delay: 0.6s">
+            <div class="upload-section animate__animated animate__fadeIn delay-60">
                 <h3 class="section-title">
                     <i class="bi bi-cloud-arrow-up-fill"></i>
                     Upload Content
@@ -1351,17 +1351,17 @@ include __DIR__.'/header.php';
                         </label>
                         <textarea class="form-control" name="custom_message" id="custom_message" rows="3"
                                   placeholder="Add any special instructions or information about these files..."
-                                  style="border-radius: 12px; border: 2px solid #e0e0e0;"></textarea>
+                                  class="textarea-rounded"></textarea>
                     </div>
 
-                    <button class="btn-modern btn-modern-primary w-100" type="submit" id="uploadBtn" style="display: none;">
+                    <button class="btn-modern btn-modern-primary w-100 d-none" type="submit" id="uploadBtn">
                         <i class="bi bi-cloud-upload"></i> Upload Files
                     </button>
                 </form>
             </div>
 
             <?php if (!empty($recent_chats)): ?>
-                <div class="chat-section animate__animated animate__fadeIn" style="animation-delay: 0.9s">
+                <div class="chat-section animate__animated animate__fadeIn delay-90">
                     <div class="chat-header">
                         <h3 class="section-title m-0 text-white">
                             <i class="bi bi-chat-dots-fill"></i>
@@ -1400,7 +1400,7 @@ include __DIR__.'/header.php';
             <!-- Right Sidebar -->
             <div>
                 <!-- Quick Actions -->
-                <div class="quick-actions animate__animated animate__fadeIn" style="animation-delay: 0.7s">
+                <div class="quick-actions animate__animated animate__fadeIn delay-70">
                     <h3 class="section-title">
                         <i class="bi bi-lightning-charge-fill"></i>
                         Quick Actions
@@ -1481,7 +1481,7 @@ include __DIR__.'/header.php';
 
                 <!-- Recent Activity -->
                 <?php if (!empty($recent_uploads)): ?>
-                    <div class="activity-section mt-3 animate__animated animate__fadeIn" style="animation-delay: 0.8s">
+                    <div class="activity-section mt-3 animate__animated animate__fadeIn delay-80">
                         <h3 class="section-title">
                             <i class="bi bi-activity"></i>
                             Recent Activity
@@ -1671,7 +1671,7 @@ include __DIR__.'/header.php';
                 </div>
                 <div class="file-description">
                     <input type="text" name="descriptions[${index}]" class="form-control form-control-sm"
-                           placeholder="Optional description" style="border-radius: 8px;">
+                           placeholder="Optional description" class="rounded-8">
                 </div>
                 <i class="bi bi-x-circle-fill file-remove" onclick="removeFile(${index})"></i>
             `;

--- a/public/marketing.php
+++ b/public/marketing.php
@@ -435,7 +435,7 @@ include __DIR__.'/header.php';
 
         <?php if ($url): ?>
             <!-- Report Container -->
-            <div class="report-container animate__animated animate__fadeIn" style="animation-delay: 0.3s" id="reportContainer">
+            <div class="report-container animate__animated animate__fadeIn delay-30" id="reportContainer">
                 <div class="report-header">
                     <div class="report-icon">
                         <i class="bi bi-graph-up-arrow"></i>
@@ -466,7 +466,7 @@ include __DIR__.'/header.php';
                     </div>
 
                     <!-- Error State (hidden by default) -->
-                    <div class="error-state" id="errorState" style="display: none;">
+                    <div class="error-state d-none" id="errorState">
                         <i class="bi bi-exclamation-triangle"></i>
                         <h3>Failed to Load Report</h3>
                         <p>There was an issue loading your marketing report. Please try again.</p>
@@ -489,7 +489,7 @@ include __DIR__.'/header.php';
 
         <?php else: ?>
             <!-- No Report State -->
-            <div class="report-container animate__animated animate__fadeIn" style="animation-delay: 0.3s">
+            <div class="report-container animate__animated animate__fadeIn delay-30">
                 <div class="no-report-state">
                     <i class="bi bi-graph-up"></i>
                     <h3>Marketing Report Not Set Up</h3>


### PR DESCRIPTION
## Summary
- add utility classes for common animation delays
- refactor PHP templates to use the delay classes
- extract some inline styles to CSS helper classes

## Testing
- `php -l admin/broadcasts.php admin/chat.php admin/edit_store.php admin/edit_store_user.php admin/edit_user.php admin/index.php admin/settings.php admin/stores.php admin/uploads.php admin/users.php public/articles.php public/calendar.php public/chat.php public/history.php public/index.php public/marketing.php`

------
https://chatgpt.com/codex/tasks/task_e_687ef849b98083269fd061068801c2f9