### PR TITLE
Fix history action buttons

### DIFF
--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -358,7 +358,7 @@ include __DIR__.'/header.php';
                                 <td class="actions-cell">
                                     <a href="https://drive.google.com/file/d/<?php echo $upload['drive_id']; ?>/view"
                                        target="_blank" class="btn btn-action btn-action-primary" title="View in Drive">
-                                        <i class="bi bi-eye"></i> View
+                                        <i class="bi bi-eye"></i>
                                     </a>
                                     <a href="https://drive.google.com/uc?export=download&id=<?php echo $upload['drive_id']; ?>"
                                        class="btn btn-action btn-action-success" title="Download">

--- a/public/history.php
+++ b/public/history.php
@@ -295,20 +295,20 @@ include __DIR__.'/header.php';
                                 </div>
                             <?php endif; ?>
 
-                            <div class="upload-actions">
+                            <div class="history-actions">
                                 <a href="https://drive.google.com/file/d/<?php echo $upload['drive_id']; ?>/view"
                                    target="_blank"
-                                   class="action-button view-button">
+                                   class="history-btn history-btn-primary">
                                     <i class="bi bi-eye"></i> View
                                 </a>
                                 <a href="https://drive.google.com/uc?export=download&id=<?php echo $upload['drive_id']; ?>"
                                    target="_blank"
-                                   class="action-button download-button">
+                                   class="history-btn history-btn-success">
                                     <i class="bi bi-download"></i> Download
                                 </a>
                                 <form method="post" class="flex-1" onsubmit="return confirmDelete('<?php echo htmlspecialchars($upload['filename']); ?>')">
                                     <input type="hidden" name="delete_id" value="<?php echo $upload['id']; ?>">
-                                    <button type="submit" class="action-button delete-button w-100">
+                                    <button type="submit" class="history-btn history-btn-danger w-100">
                                         <i class="bi bi-trash"></i> Delete
                                     </button>
                                 </form>

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -1488,10 +1488,65 @@ table th, table td {
     color: #065f46;
 }
 
+
 .download-button:hover {
     background: #065f46;
     color: white;
     transform: translateY(-2px);
+}
+
+/* History page action buttons styled like admin dashboard */
+.history-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.history-btn {
+    flex: 1;
+    padding: 0.375rem 0.75rem;
+    border-radius: 10px;
+    border: none;
+    font-weight: 500;
+    font-size: 0.875rem;
+    text-decoration: none;
+    transition: var(--transition);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+}
+
+.history-btn-primary {
+    background: #667eea;
+    color: #ffffff;
+}
+
+.history-btn-primary:hover {
+    background: #5a67d8;
+    transform: translateY(-2px);
+    color: #ffffff;
+}
+
+.history-btn-success {
+    background: #4ade80;
+    color: #ffffff;
+}
+
+.history-btn-success:hover {
+    background: #22c55e;
+    transform: translateY(-2px);
+    color: #ffffff;
+}
+
+.history-btn-danger {
+    background: #dc3545;
+    color: #ffffff;
+}
+
+.history-btn-danger:hover {
+    background: #c82333;
+    transform: translateY(-2px);
+    color: #ffffff;
 }
 
 /* Filters Section */


### PR DESCRIPTION
## Summary
- update button classes on public history page
- match admin button styling for new history classes
- show icon only for view action in admin uploads

## Testing
- `php -l public/history.php`
- `php -l admin/uploads.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687f0ad257708326b67e3294e63cc3d3