### PR TITLE
Add local uploads with thumbnails

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -11,6 +11,8 @@ return [
     'service_account_json' => __DIR__.'/service-account.json',
     'drive_base_folder' => '',
     'calendar_media_dir' => __DIR__ . '/public/calendar_media',
+    // Base directory for storing local copies of uploads
+    'local_upload_dir' => __DIR__ . '/public/uploads',
     'notification_email' => 'admin@example.com',
     'google_oauth' => [
         'client_id' => '',

--- a/update_database.php
+++ b/update_database.php
@@ -338,6 +338,21 @@ try {
     echo "• status_id column might already exist\n";
 }
 
+// Add local_path and thumb_path columns to uploads
+try {
+    $pdo->exec("ALTER TABLE uploads ADD COLUMN local_path TEXT AFTER status_id");
+    echo "✓ Added local_path column to uploads table\n";
+} catch (PDOException $e) {
+    echo "• local_path column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE uploads ADD COLUMN thumb_path TEXT AFTER local_path");
+    echo "✓ Added thumb_path column to uploads table\n";
+} catch (PDOException $e) {
+    echo "• thumb_path column might already exist\n";
+}
+
 // Insert default statuses if not already present
 $defaultStatuses = [
     ['Reviewed', '#198754'],


### PR DESCRIPTION
## Summary
- store local copies of uploads and create thumbnails
- expose new `local_upload_dir` config option
- extend database schema to hold local and thumbnail paths
- save local paths during upload and show thumbnails from local files

## Testing
- `php -l public/index.php`
- `php -l public/history.php`
- `php -l config.example.php`
- `php -l update_database.php`
- `php tests/dbtest.php`

------
https://chatgpt.com/codex/tasks/task_e_687f0faac8fc8326884e4582e24a2e15