### PR TITLE
Fix calendar events not showing due to timestamp format

### DIFF
--- a/public/calendar.php
+++ b/public/calendar.php
@@ -161,7 +161,8 @@ foreach ($posts as $p) {
     }
     $events[] = [
         'title' => $network_name ?: 'Post',
-        'start' => $time,
+        // Convert datetime to ISO format for FullCalendar
+        'start' => $time ? str_replace(' ', 'T', $time) : null,
         'backgroundColor' => $color,
         'borderColor' => $color,
         'classNames' => $class ? [$class] : ['social-default'],
@@ -170,7 +171,8 @@ foreach ($posts as $p) {
             'video' => $video,
             'icon'  => $icon,
             'text'  => $p['text'] ?? '',
-            'time'  => $time,
+            // Provide ISO datetime for display
+            'time'  => $time ? str_replace(' ', 'T', $time) : null,
             'network' => $network_name,
             'tags' => $tags
         ]


### PR DESCRIPTION
## Summary
- convert `scheduled_send_time` values to ISO timestamps when building FullCalendar events

## Testing
- `php -l public/calendar.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687fbc821a188326a01d638e15b55d9d