### PR TITLE
Add article image uploads and history quick uploader

### DIFF
--- a/cmuploader.sql
+++ b/cmuploader.sql
@@ -33,6 +33,7 @@ CREATE TABLE `articles` (
   `title` varchar(255) NOT NULL,
   `content` longtext NOT NULL,
   `excerpt` text DEFAULT NULL,
+  `images` text DEFAULT NULL,
   `status` enum('draft','submitted','approved','rejected') DEFAULT 'submitted',
   `admin_notes` text DEFAULT NULL,
   `created_at` datetime NOT NULL,

--- a/update_articles.php
+++ b/update_articles.php
@@ -71,6 +71,14 @@ try {
     echo "• Article_id column might already exist\n";
 }
 
+// Add images column to articles table
+try {
+    $pdo->exec("ALTER TABLE articles ADD COLUMN images TEXT AFTER excerpt");
+    echo "✓ Added images column to articles table\n";
+} catch (PDOException $e) {
+    echo "• Images column might already exist\n";
+}
+
 echo "\n✓ Database update complete!\n";
 echo "Article submission functionality is now available.\n";
 ?>


### PR DESCRIPTION
## Summary
- allow storing article images and persist to Drive
- add `images` column in schema and update script
- support image uploads during article creation
- quick upload to history page for images

## Testing
- `php -l public/articles.php`
- `php -l public/history.php`
- `php tests/dbtest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68800ee920008326b910776908d6cdeb