### PR TITLE
Fix logout handling and ensure sessions

### DIFF
--- a/public/articles.php
+++ b/public/articles.php
@@ -7,7 +7,7 @@ require_once __DIR__.'/../lib/drive.php';
 $config = get_config();
 $localUploadDir = $config['local_upload_dir'] ?? (__DIR__ . '/uploads');
 
-session_start();
+ensure_session();
 
 // Check if logged in
 if (!isset($_SESSION['store_id'])) {

--- a/public/calendar.php
+++ b/public/calendar.php
@@ -3,8 +3,9 @@ require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/calendar.php';
 require_once __DIR__.'/../lib/helpers.php';
 require_once __DIR__.'/../lib/hootsuite.php';
+require_once __DIR__.'/../lib/auth.php';
 
-session_start();
+ensure_session();
 
 if (!isset($_SESSION['store_id'])) {
     header('Location: index.php');

--- a/public/header.php
+++ b/public/header.php
@@ -1,5 +1,6 @@
 <?php
-if (!isset($_SESSION)) { session_start(); }
+require_once __DIR__.'/../lib/auth.php';
+ensure_session();
 
 // Get current page for active state
 $current_page = basename($_SERVER['PHP_SELF']);
@@ -161,7 +162,7 @@ if (isset($_SESSION['store_id'])) {
                 </div>
 
                 <!-- Logout -->
-                <a href="?logout=1" class="logout-btn" title="Logout">
+                <a href="logout.php" class="logout-btn" title="Logout">
                     <i class="bi bi-box-arrow-right"></i>
                 </a>
 
@@ -231,7 +232,7 @@ if (isset($_SESSION['store_id'])) {
                             <span class="user-role">Store User</span>
                         </div>
                     </div>
-                    <a href="?logout=1" class="logout-btn" title="Logout">
+                    <a href="logout.php" class="logout-btn" title="Logout">
                         <i class="bi bi-box-arrow-right"></i>
                     </a>
                 </div>

--- a/public/history.php
+++ b/public/history.php
@@ -7,7 +7,7 @@ require_once __DIR__.'/../lib/drive.php';
 $config = get_config();
 $localUploadDir = $config['local_upload_dir'] ?? (__DIR__ . '/uploads');
 
-session_start();
+ensure_session();
 
 // Check if logged in
 if (!isset($_SESSION['store_id'])) {

--- a/public/index.php
+++ b/public/index.php
@@ -13,20 +13,9 @@ ensure_session();
 $errors = [];
 $success = [];
 
-// Handle logout
+// Handle logout legacy parameter
 if (isset($_GET['logout'])) {
-    // Clear all store-related session data
-    unset($_SESSION['store_id']);
-    unset($_SESSION['store_pin']);
-    unset($_SESSION['store_name']);
-    unset($_SESSION['store_user_email']);
-    unset($_SESSION['store_first_name']);
-    unset($_SESSION['store_last_name']);
-
-    // Destroy the session completely
-    session_destroy();
-
-    header('Location: index.php');
+    header('Location: logout.php');
     exit;
 }
 

--- a/public/logout.php
+++ b/public/logout.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__.'/../lib/auth.php';
+
+ensure_session();
+
+// Clear store-related session data
+unset($_SESSION['store_id']);
+unset($_SESSION['store_pin']);
+unset($_SESSION['store_name']);
+unset($_SESSION['store_user_email']);
+unset($_SESSION['store_first_name']);
+unset($_SESSION['store_last_name']);
+
+// Destroy the session completely
+session_destroy();
+
+header('Location: index.php');
+exit;

--- a/public/marketing.php
+++ b/public/marketing.php
@@ -1,8 +1,9 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/helpers.php';
+require_once __DIR__.'/../lib/auth.php';
 
-session_start();
+ensure_session();
 
 // Check if logged in
 if (!isset($_SESSION['store_id'])) {

--- a/public/notifications.php
+++ b/public/notifications.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
-session_start();
+require_once __DIR__.'/../lib/auth.php';
+ensure_session();
 if(!isset($_SESSION['store_id'])){http_response_code(403);exit;}
 $pdo=get_pdo();
 $count=$pdo->prepare("SELECT COUNT(*) FROM store_messages WHERE store_id=? AND sender='admin' AND read_by_store=0");

--- a/public/send_message.php
+++ b/public/send_message.php
@@ -1,7 +1,8 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/helpers.php';
-session_start();
+require_once __DIR__.'/../lib/auth.php';
+ensure_session();
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(405);

--- a/public/thumbnail.php
+++ b/public/thumbnail.php
@@ -1,8 +1,9 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/drive.php';
+require_once __DIR__.'/../lib/auth.php';
 
-session_start();
+ensure_session();
 
 // Check if logged in
 if (!isset($_SESSION['store_id'])) {

--- a/public/view_article.php
+++ b/public/view_article.php
@@ -1,8 +1,9 @@
 <?php
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/helpers.php';
+require_once __DIR__.'/../lib/auth.php';
 
-session_start();
+ensure_session();
 
 // Check if logged in
 if (!isset($_SESSION['store_id'])) {


### PR DESCRIPTION
## Summary
- ensure all public pages start sessions consistently using `ensure_session`
- add dedicated `public/logout.php` to destroy store sessions
- link logout buttons to the new script
- forward legacy `?logout=1` requests to `logout.php`

## Testing
- `php -l public/logout.php`
- `php -l public/header.php`
- `php -l public/index.php`
- `php -l public/articles.php`
- `php -l public/calendar.php`
- `php -l public/history.php`
- `php -l public/marketing.php`
- `php -l public/notifications.php`
- `php -l public/send_message.php`
- `php -l public/thumbnail.php`
- `php -l public/view_article.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688014a3dc608326b804429b4693e107