### PR TITLE
Fix logout link on public pages

### DIFF
--- a/public/logout.php
+++ b/public/logout.php
@@ -1,18 +1,8 @@
 <?php
 require_once __DIR__.'/../lib/auth.php';
 
-ensure_session();
-
-// Clear store-related session data
-unset($_SESSION['store_id']);
-unset($_SESSION['store_pin']);
-unset($_SESSION['store_name']);
-unset($_SESSION['store_user_email']);
-unset($_SESSION['store_first_name']);
-unset($_SESSION['store_last_name']);
-
-// Destroy the session completely
-session_destroy();
+// Use common logout routine to fully clear the session
+logout();
 
 header('Location: index.php');
 exit;


### PR DESCRIPTION
## Summary
- ensure public logout uses common `logout()` routine

## Testing
- `php -l public/logout.php`
- `php -l lib/auth.php`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68801b934a7483268cec291fe34588a8