### PR TITLE
Unify login page styles

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -53,7 +53,6 @@ include __DIR__.'/login_header.php';
                     </div>
                     <button class="btn btn-login btn-lg w-100" type="submit">Login</button>
                 </form>
-                <p class="mt-3 text-center"><a class="btn btn-danger" href="google_login.php">Login with Google</a></p>
             </div>
         </div>
     </div>

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -97,7 +97,7 @@ body {
 
 /* Login Page Styles */
 .login-page {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background-color: #262829;
     display: flex;
     align-items: center;
     min-height: 100vh;
@@ -106,20 +106,18 @@ body {
 .login-page .login-logo {
     max-width: 200px;
     margin-bottom: 30px;
-    filter: brightness(0) invert(1); /* Make logo white on gradient background */
 }
 
 .login-page .btn-login {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    border: none;
+    background-color: #ff675b;
+    border-color: #ff675b;
     color: white;
-    font-weight: 500;
-    transition: all 0.3s ease;
 }
 
 .login-page .btn-login:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 10px 25px rgba(102, 126, 234, 0.3);
+    background-color: #e55750;
+    border-color: #e55750;
+    color: white;
 }
 
 .login-page .admin-link {

--- a/public/index.php
+++ b/public/index.php
@@ -63,6 +63,10 @@ if (!$isLoggedIn) {
         <meta name="robots" content="noindex, nofollow">
         <!-- Bootstrap CSS from CDN -->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+        <!-- Montserrat Font -->
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="inc/css/style.css">
     </head>
     <body class="login-page">


### PR DESCRIPTION
## Summary
- remove Google login option from admin login page
- style public login like the admin
- include Montserrat font for public login page

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68802166155c83268c55bc708963330e