### PR TITLE
Improve article admin view and header menu

### DIFF
--- a/admin/articles.php
+++ b/admin/articles.php
@@ -4,6 +4,8 @@ require_once __DIR__.'/../lib/auth.php';
 require_once __DIR__.'/../lib/helpers.php';
 require_login();
 $pdo = get_pdo();
+$checkCat = $pdo->query("SHOW COLUMNS FROM articles LIKE 'category'");
+$hasCategory = $checkCat->fetch() !== false;
 
 $success = [];
 $errors = [];
@@ -215,6 +217,9 @@ include __DIR__.'/header.php';
                             <th>Title</th>
                             <th>Store</th>
                             <th>Status</th>
+                            <?php if ($hasCategory): ?>
+                                <th>Category</th>
+                            <?php endif; ?>
                             <th>Submitted</th>
                             <th>Excerpt</th>
                             <th>Actions</th>
@@ -240,6 +245,9 @@ include __DIR__.'/header.php';
                                         <?php echo ucfirst($article['status']); ?>
                                     </span>
                                 </td>
+                                <?php if ($hasCategory): ?>
+                                    <td><?php echo htmlspecialchars($article['category']); ?></td>
+                                <?php endif; ?>
                                 <td><?php echo format_ts($article['created_at']); ?></td>
                                 <td class="article-excerpt">
                                     <?php
@@ -362,6 +370,9 @@ include __DIR__.'/header.php';
                             <strong>Submitted:</strong> ${data.article.created_at}
                             ${data.article.updated_at ? ` | <strong>Updated:</strong> ${data.article.updated_at}` : ''}
                         </p>
+                        ${data.article.category ? `<p class="mb-1"><strong>Category:</strong> ${data.article.category}</p>` : ''}
+                        ${data.article.tags ? `<p class="mb-1"><strong>Tags:</strong> ${data.article.tags}</p>` : ''}
+                        ${data.article.ip ? `<p class="mb-1"><strong>IP:</strong> ${data.article.ip}</p>` : ''}
                         ${data.article.excerpt ? `<p class="mb-1"><strong>Excerpt:</strong> ${data.article.excerpt}</p>` : ''}
                         ${data.article.admin_notes ? `
                             <div class="alert alert-warning py-2 px-3">
@@ -369,6 +380,11 @@ include __DIR__.'/header.php';
                             </div>
                         ` : ''}
                     </div>
+                    ${data.article.images && data.article.images.length ? `
+                        <div class="article-attachments mb-3">
+                            ${data.article.images.map(img => `<a href="${img.url}" target="_blank"><img src="${img.thumb}" class="me-2 mb-2" style="max-width:150px"></a>`).join('')}
+                        </div>
+                    ` : ''}
                     <hr>
                     <div class="article-content">
                         ${data.article.content}

--- a/admin/view_article_admin.php
+++ b/admin/view_article_admin.php
@@ -34,6 +34,24 @@ if ($article['updated_at']) {
     $article['updated_at'] = format_ts($article['updated_at']);
 }
 
+// Parse attachments if available
+$images = [];
+if (!empty($article['images'])) {
+    $decoded = json_decode($article['images'], true);
+    if (is_array($decoded)) {
+        foreach ($decoded as $img) {
+            $path = $img['local_path'] ?? '';
+            $thumb = $img['thumb_path'] ?? $path;
+            $images[] = [
+                'url' => '/' . ltrim($path, '/'),
+                'thumb' => '/' . ltrim($thumb, '/'),
+                'filename' => $img['filename'] ?? basename($path)
+            ];
+        }
+    }
+}
+$article['images'] = $images;
+
 // Get status class for badge
 $statusClass = [
     'draft' => 'secondary',

--- a/public/header.php
+++ b/public/header.php
@@ -73,17 +73,6 @@ if (isset($_SESSION['store_id'])) {
                     <a class="nav-link-modern <?php echo $current_page == 'articles.php' ? 'active' : ''; ?>" href="articles.php">
                         <i class="bi bi-pencil-square"></i>
                         <span>Articles</span>
-                        <?php
-                        $article_count = 0;
-                        try {
-                            $stmt = $pdo->prepare('SELECT COUNT(*) FROM articles WHERE store_id = ?');
-                            $stmt->execute([$_SESSION['store_id']]);
-                            $article_count = $stmt->fetchColumn();
-                        } catch (Exception $e) {}
-                        if ($article_count > 0):
-                            ?>
-                            <span class="nav-badge"><?php echo $article_count; ?></span>
-                        <?php endif; ?>
                     </a>
                 </li>
                 <li class="nav-item-modern">
@@ -200,9 +189,6 @@ if (isset($_SESSION['store_id'])) {
                         <a class="mobile-menu-link <?php echo $current_page == 'articles.php' ? 'active' : ''; ?>" href="articles.php">
                             <i class="bi bi-pencil-square"></i>
                             Articles
-                            <?php if ($article_count > 0): ?>
-                                <span class="nav-badge ms-auto"><?php echo $article_count; ?></span>
-                            <?php endif; ?>
                         </a>
                     </li>
                     <li class="mobile-menu-item">


### PR DESCRIPTION
## Summary
- remove badge showing article count in public header
- support optional article category column in admin listing
- show more article details and attachments in admin article modal
- parse and return images via view_article_admin endpoint

## Testing
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68804c37684c8326a3a9d6edb768fdad