### PR TITLE
Add persistent thumbnail support

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -270,7 +270,8 @@ include __DIR__.'/header.php';
                                     <?php foreach ($recent_uploads as $upload): ?>
                                         <tr>
                                             <td>
-                                                <img src="thumbnail.php?id=<?php echo $upload['id']; ?>&size=small"
+                                                <?php $thumb = !empty($upload['thumb_path']) ? $upload['thumb_path'] : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
+                                                <img src="<?php echo htmlspecialchars($thumb); ?>"
                                                      class="preview-img-sm"
                                                      alt="<?php echo htmlspecialchars($upload['filename']); ?>"
                                                      loading="lazy">

--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -140,7 +140,8 @@ function render_upload_row($upload, $statuses) {
     <tr>
         <td>
             <div class="media-preview">
-                <img src="thumbnail.php?id=<?php echo $upload['id']; ?>&size=small" alt="<?php echo htmlspecialchars($upload['filename']); ?>" loading="lazy">
+                <?php $thumb = !empty($upload['thumb_path']) ? $upload['thumb_path'] : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
+                <img src="<?php echo htmlspecialchars($thumb); ?>" alt="<?php echo htmlspecialchars($upload['filename']); ?>" loading="lazy">
                 <?php if ($isVideo): ?>
                     <div class="video-indicator"><i class="bi bi-play-fill"></i></div>
                 <?php endif; ?>
@@ -406,7 +407,8 @@ include __DIR__.'/header.php';
                             <tr>
                                 <td>
                                     <div class="media-preview">
-                                        <img src="thumbnail.php?id=<?php echo $upload['id']; ?>&size=small"
+                                        <?php $thumb = !empty($upload['thumb_path']) ? $upload['thumb_path'] : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
+                                        <img src="<?php echo htmlspecialchars($thumb); ?>"
                                              alt="<?php echo htmlspecialchars($upload['filename']); ?>"
                                              loading="lazy">
                                         <?php if ($isVideo): ?>

--- a/chat_upload.php
+++ b/chat_upload.php
@@ -4,8 +4,15 @@ require_once __DIR__.'/lib/helpers.php';
 require_once __DIR__.'/lib/auth.php';
 require_once __DIR__.'/lib/drive.php';
 
+$config = get_config();
+$localUploadDir = $config['local_upload_dir'] ?? (__DIR__ . '/public/uploads');
+
 ensure_session();
 $pdo = get_pdo();
+
+$cols = $pdo->query("SHOW COLUMNS FROM uploads")->fetchAll(PDO::FETCH_COLUMN);
+$hasLocalPath = in_array('local_path', $cols, true);
+$hasThumbPath = in_array('thumb_path', $cols, true);
 
 $isAdmin = isset($_SESSION['user_id']);
 $store_id = 0;
@@ -22,18 +29,56 @@ if ($store_id <= 0 || !isset($_FILES['file']) || !is_uploaded_file($_FILES['file
 }
 
 $parent_id = intval($_POST['parent_id'] ?? 0) ?: null;
-$tmp = $_FILES['file']['tmp_name'];
+$tmp  = $_FILES['file']['tmp_name'];
 $orig = $_FILES['file']['name'];
 $size = $_FILES['file']['size'];
 $finfo = finfo_open(FILEINFO_MIME_TYPE);
-$mime = finfo_file($finfo, $tmp);
+$mime  = finfo_file($finfo, $tmp);
 finfo_close($finfo);
 
 try {
     $folderId = get_or_create_store_folder($store_id);
-    $driveId = drive_upload($tmp, $mime, $orig, $folderId);
-    $ins = $pdo->prepare('INSERT INTO uploads (store_id, filename, created_at, ip, mime, size, drive_id) VALUES (?, ?, NOW(), ?, ?, ?, ?)');
-    $ins->execute([$store_id, $orig, $_SERVER['REMOTE_ADDR'] ?? '', $mime, $size, $driveId]);
+
+    $subDir = $store_id . '/' . date('Y/m');
+    $targetDir = rtrim($localUploadDir, '/\\') . '/' . $subDir;
+    $thumbDir  = $targetDir . '/thumbs';
+    if (!is_dir($thumbDir) && !mkdir($thumbDir, 0777, true) && !is_dir($thumbDir)) {
+        throw new Exception('Failed to create upload directory');
+    }
+
+    $safeName = preg_replace('/[^A-Za-z0-9._-]/', '_', basename($orig));
+    $localPath = $targetDir . '/' . $safeName;
+    if (!move_uploaded_file($tmp, $localPath)) {
+        throw new Exception('Failed to store file locally');
+    }
+
+    $thumbPath = $thumbDir . '/' . $safeName;
+    $thumbUrl = null;
+    if ($hasThumbPath && create_local_thumbnail($localPath, $thumbPath, $mime)) {
+        $thumbUrl = 'uploads/' . $subDir . '/thumbs/' . $safeName;
+    }
+
+    $driveId = drive_upload($localPath, $mime, $orig, $folderId);
+
+    $fields = ['store_id', 'filename', 'created_at', 'ip', 'mime', 'size', 'drive_id'];
+    $placeholders = '?, ?, NOW(), ?, ?, ?, ?';
+    $values = [$store_id, $orig, $_SERVER['REMOTE_ADDR'] ?? '', $mime, $size, $driveId];
+
+    if ($hasLocalPath) {
+        $fields[] = 'local_path';
+        $placeholders .= ', ?';
+        $values[] = 'uploads/' . $subDir . '/' . $safeName;
+    }
+
+    if ($hasThumbPath) {
+        $fields[] = 'thumb_path';
+        $placeholders .= ', ?';
+        $values[] = $thumbUrl;
+    }
+
+    $sql = 'INSERT INTO uploads (' . implode(',', $fields) . ') VALUES (' . $placeholders . ')';
+    $ins = $pdo->prepare($sql);
+    $ins->execute($values);
     $upload_id = $pdo->lastInsertId();
 
     $sender = $isAdmin ? 'admin' : 'store';
@@ -48,5 +93,30 @@ try {
 } catch (Exception $e) {
     http_response_code(500);
     echo json_encode(['error' => $e->getMessage()]);
+}
+
+function create_local_thumbnail(string $src, string $dest, string $mime): bool {
+    $max = 400;
+    if (strpos($mime, 'image/') === 0) {
+        $img = @imagecreatefromstring(file_get_contents($src));
+        if (!$img) return false;
+        $w = imagesx($img);
+        $h = imagesy($img);
+        $scale = min($max / $w, $max / $h, 1);
+        $tw = (int)($w * $scale);
+        $th = (int)($h * $scale);
+        $thumb = imagecreatetruecolor($tw, $th);
+        imagecopyresampled($thumb, $img, 0, 0, 0, 0, $tw, $th, $w, $h);
+        imagejpeg($thumb, $dest, 80);
+        imagedestroy($img);
+        imagedestroy($thumb);
+        return true;
+    }
+    if (strpos($mime, 'video/') === 0) {
+        $cmd = 'ffmpeg -y -i ' . escapeshellarg($src) . ' -ss 00:00:01 -frames:v 1 -vf scale=' . $max . ':-1 ' . escapeshellarg($dest) . ' 2>/dev/null';
+        exec($cmd);
+        return file_exists($dest);
+    }
+    return false;
 }
 


### PR DESCRIPTION
## Summary
- generate local thumbnails when chat attachments are uploaded
- store thumbnail path on chat uploads and show stored thumbs on pages
- show stored thumbnails in the admin dashboard and upload listings

## Testing
- `php -l chat_upload.php`
- `php -l admin/chat.php`
- `php -l admin/uploads.php`
- `php -l admin/index.php`
- `php tests/dbtest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68804e10f1908326b8475cfbf15b272f