### PR TITLE
Fix admin thumbnails and ordering

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -137,7 +137,7 @@ $stmt = $pdo->query('
     FROM uploads u
     JOIN stores s ON u.store_id = s.id
     LEFT JOIN upload_statuses us ON u.status_id = us.id
-    ORDER BY u.created_at DESC
+    ORDER BY u.created_at DESC, u.id DESC
     LIMIT 5
 ');
 $recent_uploads = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -270,7 +270,7 @@ include __DIR__.'/header.php';
                                     <?php foreach ($recent_uploads as $upload): ?>
                                         <tr>
                                             <td>
-                                                <?php $thumb = !empty($upload['thumb_path']) ? $upload['thumb_path'] : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
+                                                <?php $thumb = !empty($upload['thumb_path']) ? '/' . ltrim($upload['thumb_path'], '/') : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
                                                 <img src="<?php echo htmlspecialchars($thumb); ?>"
                                                      class="preview-img-sm"
                                                      alt="<?php echo htmlspecialchars($upload['filename']); ?>"

--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -108,7 +108,7 @@ $total = $stmt->fetchColumn();
 $total_pages = ceil($total / $per_page);
 
 // Get uploads
-$query .= ' ORDER BY u.created_at DESC LIMIT ' . $per_page . ' OFFSET ' . $offset;
+$query .= ' ORDER BY u.created_at DESC, u.id DESC LIMIT ' . $per_page . ' OFFSET ' . $offset;
 $stmt = $pdo->prepare($query);
 $stmt->execute($params);
 $uploads = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -140,7 +140,7 @@ function render_upload_row($upload, $statuses) {
     <tr>
         <td>
             <div class="media-preview">
-                <?php $thumb = !empty($upload['thumb_path']) ? $upload['thumb_path'] : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
+                <?php $thumb = !empty($upload['thumb_path']) ? '/' . ltrim($upload['thumb_path'], '/') : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
                 <img src="<?php echo htmlspecialchars($thumb); ?>" alt="<?php echo htmlspecialchars($upload['filename']); ?>" loading="lazy">
                 <?php if ($isVideo): ?>
                     <div class="video-indicator"><i class="bi bi-play-fill"></i></div>
@@ -407,7 +407,7 @@ include __DIR__.'/header.php';
                             <tr>
                                 <td>
                                     <div class="media-preview">
-                                        <?php $thumb = !empty($upload['thumb_path']) ? $upload['thumb_path'] : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
+                                        <?php $thumb = !empty($upload['thumb_path']) ? '/' . ltrim($upload['thumb_path'], '/') : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
                                         <img src="<?php echo htmlspecialchars($thumb); ?>"
                                              alt="<?php echo htmlspecialchars($upload['filename']); ?>"
                                              loading="lazy">


### PR DESCRIPTION
## Summary
- fix ORDER BY for recent uploads and listing
- ensure admin uses absolute thumbnail paths

## Testing
- `php -l admin/index.php`
- `php -l admin/uploads.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688051626a7c83269cdd55ae9158b727