### PR TITLE
Fix thumbnail paths

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -270,7 +270,7 @@ include __DIR__.'/header.php';
                                     <?php foreach ($recent_uploads as $upload): ?>
                                         <tr>
                                             <td>
-                                                <?php $thumb = !empty($upload['thumb_path']) ? '/' . ltrim($upload['thumb_path'], '/') : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
+                                                <?php $thumb = !empty($upload['thumb_path']) ? '/public/' . ltrim($upload['thumb_path'], '/') : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
                                                 <img src="<?php echo htmlspecialchars($thumb); ?>"
                                                      class="preview-img-sm"
                                                      alt="<?php echo htmlspecialchars($upload['filename']); ?>"

--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -140,7 +140,7 @@ function render_upload_row($upload, $statuses) {
     <tr>
         <td>
             <div class="media-preview">
-                <?php $thumb = !empty($upload['thumb_path']) ? '/' . ltrim($upload['thumb_path'], '/') : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
+                <?php $thumb = !empty($upload['thumb_path']) ? '/public/' . ltrim($upload['thumb_path'], '/') : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
                 <img src="<?php echo htmlspecialchars($thumb); ?>" alt="<?php echo htmlspecialchars($upload['filename']); ?>" loading="lazy">
                 <?php if ($isVideo): ?>
                     <div class="video-indicator"><i class="bi bi-play-fill"></i></div>
@@ -407,7 +407,7 @@ include __DIR__.'/header.php';
                             <tr>
                                 <td>
                                     <div class="media-preview">
-                                        <?php $thumb = !empty($upload['thumb_path']) ? '/' . ltrim($upload['thumb_path'], '/') : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
+                                        <?php $thumb = !empty($upload['thumb_path']) ? '/public/' . ltrim($upload['thumb_path'], '/') : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
                                         <img src="<?php echo htmlspecialchars($thumb); ?>"
                                              alt="<?php echo htmlspecialchars($upload['filename']); ?>"
                                              loading="lazy">


### PR DESCRIPTION
## Summary
- fix thumbnail image paths in admin interface

## Testing
- `php -l admin/index.php`
- `php -l admin/uploads.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6880555c650c8326b6995f134a549576