### PR TITLE
Fix admin thumbnail paths

### DIFF
--- a/admin/chat.php
+++ b/admin/chat.php
@@ -87,6 +87,7 @@ $stmt = $pdo->prepare("SELECT m.*, s.name as store_name,
         $m['like_by_store'] = (int)$m['like_by_store'];
         $m['love_by_admin'] = (int)$m['love_by_admin'];
         $m['love_by_store'] = (int)$m['love_by_store'];
+        if (!empty($m["thumb_path"])) $m["thumb_path"] = public_upload_url($m["thumb_path"]);
     }
     header('Content-Type: application/json');
     echo json_encode($msgs);
@@ -133,6 +134,7 @@ if ($current_store_id) {
         $m['like_by_store'] = (int)$m['like_by_store'];
         $m['love_by_admin'] = (int)$m['love_by_admin'];
         $m['love_by_store'] = (int)$m['love_by_store'];
+        if (!empty($m["thumb_path"])) $m["thumb_path"] = public_upload_url($m["thumb_path"]);
     }
     $upd = $pdo->prepare("UPDATE store_messages SET read_by_admin=1 WHERE store_id=? AND sender='store' AND read_by_admin=0");
     $upd->execute([$current_store_id]);
@@ -361,7 +363,7 @@ include __DIR__.'/header.php';
                                         </div>
                                         <?php if (!empty($msg['filename'])): ?>
                                             <?php if (strpos($msg['mime'], 'image/') === 0): ?>
-                                                <?php $thumbSrc = !empty($msg['thumb_path']) ? $msg['thumb_path'] : 'thumbnail.php?id=' . $msg['upload_id'] . '&size=medium'; ?>
+                                                <?php $thumbSrc = !empty($msg['thumb_path']) ? public_upload_url($msg['thumb_path']) : 'thumbnail.php?id=' . $msg['upload_id'] . '&size=medium'; ?>
                                                 <div class="mb-1"><a href="https://drive.google.com/uc?export=view&id=<?php echo $msg['drive_id']; ?>" target="_blank"><img src="<?php echo htmlspecialchars($thumbSrc); ?>" alt="<?php echo htmlspecialchars($msg['filename']); ?>" class="message-img"></a></div>
                                             <?php elseif (strpos($msg['mime'], 'video/') === 0): ?>
                                                 <div class="mb-1"><video src="https://drive.google.com/uc?export=view&id=<?php echo $msg['drive_id']; ?>" controls class="message-video"></video></div>

--- a/admin/index.php
+++ b/admin/index.php
@@ -270,7 +270,7 @@ include __DIR__.'/header.php';
                                     <?php foreach ($recent_uploads as $upload): ?>
                                         <tr>
                                             <td>
-                                                <?php $thumb = !empty($upload['thumb_path']) ? '/' . ltrim($upload['thumb_path'], '/') : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
+                                                <?php $thumb = !empty($upload['thumb_path']) ? public_upload_url($upload['thumb_path']) : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
                                                 <img src="<?php echo htmlspecialchars($thumb); ?>"
                                                      class="preview-img-sm"
                                                      alt="<?php echo htmlspecialchars($upload['filename']); ?>"

--- a/admin/uploads.php
+++ b/admin/uploads.php
@@ -140,7 +140,7 @@ function render_upload_row($upload, $statuses) {
     <tr>
         <td>
             <div class="media-preview">
-                <?php $thumb = !empty($upload['thumb_path']) ? '/' . ltrim($upload['thumb_path'], '/') : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
+                <?php $thumb = !empty($upload['thumb_path']) ? public_upload_url($upload['thumb_path']) : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
                 <img src="<?php echo htmlspecialchars($thumb); ?>" alt="<?php echo htmlspecialchars($upload['filename']); ?>" loading="lazy">
                 <?php if ($isVideo): ?>
                     <div class="video-indicator"><i class="bi bi-play-fill"></i></div>
@@ -407,7 +407,7 @@ include __DIR__.'/header.php';
                             <tr>
                                 <td>
                                     <div class="media-preview">
-                                        <?php $thumb = !empty($upload['thumb_path']) ? '/' . ltrim($upload['thumb_path'], '/') : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
+                                        <?php $thumb = !empty($upload['thumb_path']) ? public_upload_url($upload['thumb_path']) : 'thumbnail.php?id=' . $upload['id'] . '&size=small'; ?>
                                         <img src="<?php echo htmlspecialchars($thumb); ?>"
                                              alt="<?php echo htmlspecialchars($upload['filename']); ?>"
                                              loading="lazy">

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -139,3 +139,12 @@ function normalize_tag(?string $tag): string {
     $tag = ltrim($tag, "#");
     return strtolower($tag);
 }
+
+/**
+ * Get the public URL for an uploaded file path.
+ * Adds the /public prefix to local paths stored in the database.
+ */
+function public_upload_url(?string $path): ?string {
+    if (!$path) return $path;
+    return "/public/" . ltrim($path, "/");
+}


### PR DESCRIPTION
## Summary
- add `public_upload_url()` helper
- ensure admin thumbnails use `/public` path
- expose public path in chat API

## Testing
- `php -l lib/helpers.php`
- `php -l admin/uploads.php`
- `php -l admin/index.php`
- `php -l admin/chat.php`
- `php tests/dbtest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68806b3b122c83269e9de5e83808267c