### PR TITLE
fix: include root config in hootsuite scripts

### DIFF
--- a/lib/hootsuite/access_token.php
+++ b/lib/hootsuite/access_token.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 
-include('config.php'); // Include config to get credentials
+include __DIR__ . '/../../config.php'; // Include config to get credentials
 
 // Step 1: Check if the access token is already available in the session
 if (isset($_SESSION['access_token'])) {

--- a/lib/hootsuite/debug_hootsuite.php
+++ b/lib/hootsuite/debug_hootsuite.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-include('config.php');
+include __DIR__ . '/../../config.php';
 
 // Set JSON content type
 header('Content-Type: application/json');

--- a/lib/hootsuite/diagnostic_posts.php
+++ b/lib/hootsuite/diagnostic_posts.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-include('config.php');
+include __DIR__ . '/../../config.php';
 
 // Set JSON content type
 header('Content-Type: text/html; charset=utf-8');

--- a/lib/hootsuite/get_scheduled_posts.php
+++ b/lib/hootsuite/get_scheduled_posts.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-include('config.php');
+include __DIR__ . '/../../config.php';
 
 // Check if we have an access token
 if (!isset($_SESSION['access_token'])) {

--- a/lib/hootsuite/get_scheduled_posts_json.php
+++ b/lib/hootsuite/get_scheduled_posts_json.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-include('config.php');
+include __DIR__ . '/../../config.php';
 
 // Set JSON content type
 header('Content-Type: application/json');

--- a/lib/hootsuite/get_social_profiles.php
+++ b/lib/hootsuite/get_social_profiles.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-include('config.php');
+include __DIR__ . '/../../config.php';
 
 // Check if we have an access token
 if (!isset($_SESSION['access_token'])) {

--- a/lib/hootsuite/listing.php
+++ b/lib/hootsuite/listing.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-include('config.php');
+include __DIR__ . '/../../config.php';
 
 // Check if we have an access token
 if (!isset($_SESSION['access_token'])) {

--- a/lib/hootsuite/refresh_token.php
+++ b/lib/hootsuite/refresh_token.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-include('config.php');
+include __DIR__ . '/../../config.php';
 
 if (!isset($_SESSION['refresh_token'])) {
     die("No refresh token found. Please authenticate again.");

--- a/lib/hootsuite/simple_posts.php
+++ b/lib/hootsuite/simple_posts.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-include('config.php');
+include __DIR__ . '/../../config.php';
 
 // Check if we have an access token
 if (!isset($_SESSION['access_token'])) {

--- a/lib/hootsuite/test_api_direct.php
+++ b/lib/hootsuite/test_api_direct.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-include('config.php');
+include __DIR__ . '/../../config.php';
 
 // Check if we have an access token
 if (!isset($_SESSION['access_token'])) {

--- a/lib/hootsuite/test_auth.php
+++ b/lib/hootsuite/test_auth.php
@@ -1,11 +1,12 @@
 <?php
 // Debug: Check if config.php exists and is readable
-if (!file_exists('config.php')) {
+$configPath = __DIR__ . '/../../config.php';
+if (!file_exists($configPath)) {
     die('Error: config.php file not found');
 }
 
 // Include the config.php file to access Hootsuite credentials
-include('config.php');
+include $configPath;
 
 // Debug: Check if constants are defined
 if (!defined('HOOTSUITE_CLIENT_ID')) {


### PR DESCRIPTION
## Summary
- ensure Hootsuite helper scripts load the root-level config file
- adjust test_auth to verify and include the resolved config path

## Testing
- `php -l lib/hootsuite/access_token.php lib/hootsuite/diagnostic_posts.php lib/hootsuite/get_scheduled_posts.php lib/hootsuite/get_social_profiles.php lib/hootsuite/refresh_token.php lib/hootsuite/get_scheduled_posts_json.php lib/hootsuite/listing.php lib/hootsuite/simple_posts.php lib/hootsuite/test_api_direct.php lib/hootsuite/debug_hootsuite.php lib/hootsuite/test_auth.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892c60a76bc8326bb281b81c6dd763c