### PR TITLE
Add manual and scheduled Hootsuite token refresh with debug details

### DIFF
--- a/callback.php
+++ b/callback.php
@@ -57,14 +57,21 @@ if (isset($_GET['code'])) {
     if (isset($token_data['access_token'])) {
         $access_token = $token_data['access_token'];
 
-        // Store in session
+        // Store in session for immediate use
         $_SESSION['access_token'] = $access_token;
         if (isset($token_data['refresh_token'])) {
             $_SESSION['refresh_token'] = $token_data['refresh_token'];
         }
 
+        // Persist tokens in settings for long term storage
+        set_setting('hootsuite_access_token', $access_token);
+        if (isset($token_data['refresh_token'])) {
+            set_setting('hootsuite_refresh_token', $token_data['refresh_token']);
+        }
+        set_setting('hootsuite_token_last_refresh', date('Y-m-d H:i:s'));
+
         echo "<div style='background: #d4edda; border: 1px solid #c3e6cb; padding: 10px; margin: 10px 0;'>";
-        echo "<strong>✅ Access token received and stored in session!</strong><br>";
+        echo "<strong>✅ Access token received and stored!</strong><br>";
         echo "Session ID: " . session_id() . "<br>";
         echo "Access Token (first 20 chars): " . substr($access_token, 0, 20) . "...<br>";
         if (isset($_SESSION['refresh_token'])) {

--- a/hoot/hootsuite_sync.php
+++ b/hoot/hootsuite_sync.php
@@ -7,10 +7,20 @@ function hootsuite_update(bool $force = false, bool $debug = false): array {
     if ($enabled !== '1') {
         return [false, 'Hootsuite integration disabled'];
     }
+    $interval = (int)(get_setting('hootsuite_update_interval') ?: 24);
+    $last = get_setting('hootsuite_last_update');
+    if (!$force && $last && (time() - strtotime($last) < $interval * 3600)) {
+        return [false, 'Update not required yet'];
+    }
+
     // Placeholder for real sync logic
+    set_setting('hootsuite_last_update', date('Y-m-d H:i:s'));
     $msg = $force ? 'Forced Hootsuite sync executed' : 'Hootsuite sync executed';
     if ($debug) {
-        $msg .= ' (debug mode)';
+        $token = get_setting('hootsuite_access_token');
+        $last = get_setting('hootsuite_token_last_refresh');
+        $msg .= ' | token snippet: ' . ($token ? substr($token, 0, 8) . '...' : 'none');
+        $msg .= ' | last refresh: ' . ($last ?: 'never');
     }
     return [true, $msg];
 }
@@ -35,7 +45,7 @@ function hootsuite_test_connection(bool $debug = false): array {
     // Real implementation would attempt an OAuth handshake
     $msg = 'OAuth settings present';
     if ($debug) {
-        $msg .= ' (debug mode)';
+        $msg .= ' | client_id snippet: ' . substr($id, 0, 8) . '...';
     }
     return [true, $msg];
 }

--- a/hoot/hootsuite_token_cron.php
+++ b/hoot/hootsuite_token_cron.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__.'/../lib/settings.php';
+require_once __DIR__.'/../lib/hootsuite/refresh_token.php';
+
+$enabled = get_setting('hootsuite_enabled');
+if ($enabled !== '1') {
+    echo "Hootsuite integration disabled" . PHP_EOL;
+    exit;
+}
+
+$interval = (int)(get_setting('hootsuite_token_refresh_interval') ?: 24);
+$last = get_setting('hootsuite_token_last_refresh');
+if ($last && (time() - strtotime($last) < $interval * 3600)) {
+    echo "Token refresh not required yet" . PHP_EOL;
+    exit;
+}
+
+[$ok, $msg] = hootsuite_refresh_token(false);
+
+echo ($ok ? 'SUCCESS: ' : 'ERROR: ') . $msg . PHP_EOL;

--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -175,6 +175,9 @@ function calendar_cache_media(array $urls, string $dir, ?string $datetime = null
 }
 
 function calendar_update(bool $force = false): array {
+    if (get_setting('calendar_enabled') !== '1') {
+        return [false, 'Calendar integration disabled'];
+    }
     $sheetId = get_setting('calendar_sheet_id');
     $sheetRange = get_setting('calendar_sheet_range') ?: 'Sheet1!A:A';
     $sheetUrl = get_setting('calendar_sheet_url');

--- a/lib/hootsuite/refresh_token.php
+++ b/lib/hootsuite/refresh_token.php
@@ -1,48 +1,65 @@
 <?php
-session_start();
-include __DIR__ . '/../../config.php';
+require_once __DIR__.'/../settings.php';
 
-if (!isset($_SESSION['refresh_token'])) {
-    die("No refresh token found. Please authenticate again.");
-}
-
-$refresh_token = $_SESSION['refresh_token'];
-
-// Exchange refresh token for new access token
-$token_url = "https://platform.hootsuite.com/oauth2/token";
-$data = array(
-    'grant_type' => 'refresh_token',
-    'refresh_token' => $refresh_token,
-    'client_id' => HOOTSUITE_CLIENT_ID,
-    'client_secret' => HOOTSUITE_CLIENT_SECRET
-);
-
-$ch = curl_init();
-curl_setopt($ch, CURLOPT_URL, $token_url);
-curl_setopt($ch, CURLOPT_POST, true);
-curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
-curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-    'Content-Type: application/x-www-form-urlencoded'
-));
-
-$response = curl_exec($ch);
-$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-curl_close($ch);
-
-if ($http_code == 200) {
-    $token_data = json_decode($response, true);
-
-    // Update session with new tokens
-    $_SESSION['access_token'] = $token_data['access_token'];
-    if (isset($token_data['refresh_token'])) {
-        $_SESSION['refresh_token'] = $token_data['refresh_token'];
+/**
+ * Refresh the Hootsuite access token using the stored refresh token.
+ *
+ * @param bool $debug When true, includes HTTP details in the response message.
+ * @return array [success:boolean, message:string]
+ */
+function hootsuite_refresh_token(bool $debug = false): array {
+    $refresh_token = get_setting('hootsuite_refresh_token');
+    $client_id = get_setting('hootsuite_client_id');
+    $client_secret = get_setting('hootsuite_client_secret');
+    if (!$refresh_token || !$client_id || !$client_secret) {
+        return [false, 'Missing refresh token or OAuth credentials'];
     }
 
-    echo "Token refreshed successfully!<br>";
-    echo "New access token is valid for " . $token_data['expires_in'] . " seconds.<br>";
-} else {
-    echo "Error refreshing token. HTTP Code: " . $http_code . "<br>";
-    echo "Response: " . $response;
+    $token_url = 'https://platform.hootsuite.com/oauth2/token';
+    $data = [
+        'grant_type' => 'refresh_token',
+        'refresh_token' => $refresh_token,
+        'client_id' => $client_id,
+        'client_secret' => $client_secret
+    ];
+
+    $ch = curl_init($token_url);
+    curl_setopt_array($ch, [
+        CURLOPT_POST => true,
+        CURLOPT_POSTFIELDS => http_build_query($data),
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => ['Content-Type: application/x-www-form-urlencoded']
+    ]);
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $curl_error = curl_error($ch);
+    curl_close($ch);
+
+    if ($curl_error) {
+        return [false, 'cURL error: ' . $curl_error];
+    }
+
+    if ($http_code === 200) {
+        $token_data = json_decode($response, true);
+        if (!isset($token_data['access_token'])) {
+            return [false, 'Invalid token response'];
+        }
+        set_setting('hootsuite_access_token', $token_data['access_token']);
+        if (isset($token_data['refresh_token'])) {
+            set_setting('hootsuite_refresh_token', $token_data['refresh_token']);
+        }
+        set_setting('hootsuite_token_last_refresh', date('Y-m-d H:i:s'));
+        $msg = 'Token refreshed successfully';
+        if ($debug) {
+            $msg .= " | HTTP $http_code | Response: " . $response;
+        }
+        return [true, $msg];
+    }
+
+    $msg = 'Error refreshing token. HTTP ' . $http_code;
+    if ($debug) {
+        $msg .= ' | Response: ' . $response;
+    }
+    return [false, $msg];
 }
-?>


### PR DESCRIPTION
## Summary
- Allow storing and refreshing Hootsuite tokens from settings
- Add token refresh controls, explanations and safety checks to admin page
- Support cron-based token refresh with debug-rich Hootsuite sync

## Testing
- `php -l lib/hootsuite/refresh_token.php`
- `php -l callback.php`
- `php -l admin/settings.php`
- `php -l hoot/hootsuite_sync.php`
- `php -l hoot/hootsuite_token_cron.php`
- `php -l lib/calendar.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892d4c29e6083268ae8f725fc50fbab