### PR TITLE
Add Hootsuite OAuth authentication in admin settings

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -270,6 +270,7 @@ $hootsuite_client_id = get_setting('hootsuite_client_id') ?: '';
 $hootsuite_client_secret = get_setting('hootsuite_client_secret') ?: '';
 $hootsuite_redirect_uri = get_setting('hootsuite_redirect_uri') ?: '';
 $hootsuite_debug = get_setting('hootsuite_debug') ?: '0';
+$hootsuite_access_token = get_setting('hootsuite_access_token') ?: '';
 $groundhogg_site_url = get_setting('groundhogg_site_url');
 $groundhogg_username = get_setting('groundhogg_username');
 $groundhogg_public_key = get_setting('groundhogg_public_key');
@@ -865,6 +866,12 @@ include __DIR__.'/header.php';
                                     </label>
                                     <input type="text" name="hootsuite_redirect_uri" id="hootsuite_redirect_uri" class="form-control form-control-modern" value="<?php echo htmlspecialchars($hootsuite_redirect_uri); ?>">
                                 </div>
+                                <div class="col-md-12">
+                                    <label for="hootsuite_access_token" class="form-label-modern">
+                                        <i class="bi bi-shield-check"></i> Access Token
+                                    </label>
+                                    <input type="text" id="hootsuite_access_token" class="form-control form-control-modern" value="<?php echo htmlspecialchars($hootsuite_access_token); ?>" readonly>
+                                </div>
                                 <div class="col-md-4">
                                     <label for="hootsuite_update_interval" class="form-label-modern">
                                         <i class="bi bi-clock"></i> Sync Interval (hours)
@@ -892,6 +899,9 @@ include __DIR__.'/header.php';
                                     <i class="bi bi-arrow-repeat"></i> Hootsuite Actions
                                 </h6>
                                 <div class="d-flex flex-wrap gap-2">
+                                    <a class="btn btn-secondary-modern btn-sm-modern" href="../lib/hootsuite/test_auth.php">
+                                        <i class="bi bi-box-arrow-in-right"></i> Authenticate
+                                    </a>
                                     <button class="btn btn-secondary-modern btn-sm-modern" type="submit" name="test_hootsuite_connection">
                                         <i class="bi bi-plug"></i> Test Connection
                                     </button>

--- a/lib/hootsuite/test_auth.php
+++ b/lib/hootsuite/test_auth.php
@@ -1,34 +1,23 @@
 <?php
-// Debug: Check if config.php exists and is readable
-$configPath = __DIR__ . '/../../config.php';
-if (!file_exists($configPath)) {
-    die('Error: config.php file not found');
+// Launches the OAuth flow for Hootsuite using credentials stored in the settings table.
+
+require_once __DIR__ . '/../settings.php';
+
+// Retrieve stored client details
+$client_id    = get_setting('hootsuite_client_id');
+$redirect_uri = get_setting('hootsuite_redirect_uri');
+
+if (!$client_id || !$redirect_uri) {
+    die('Error: Hootsuite client ID or redirect URI not configured.');
 }
 
-// Include the config.php file to access Hootsuite credentials
-include $configPath;
+// Build the Hootsuite authorization URL
+$auth_url = 'https://platform.hootsuite.com/oauth2/auth?client_id=' . urlencode($client_id)
+    . '&redirect_uri=' . urlencode($redirect_uri)
+    . '&response_type=code&scope=offline';
 
-// Debug: Check if constants are defined
-if (!defined('HOOTSUITE_CLIENT_ID')) {
-    die('Error: HOOTSUITE_CLIENT_ID not defined in config.php');
-}
-
-if (!defined('HOOTSUITE_REDIRECT_URI')) {
-    die('Error: HOOTSUITE_REDIRECT_URI not defined in config.php');
-}
-
-// Debug: Display the values (remove this in production!)
-echo "Client ID: " . HOOTSUITE_CLIENT_ID . "<br>";
-echo "Redirect URI: " . HOOTSUITE_REDIRECT_URI . "<br>";
-
-// Build the Hootsuite OAuth URL using the defined constants from config.php
-$auth_url = "https://platform.hootsuite.com/oauth2/auth?client_id=" . HOOTSUITE_CLIENT_ID . "&redirect_uri=" . urlencode(HOOTSUITE_REDIRECT_URI) . "&response_type=code&scope=offline";
-
-// Debug: Show the constructed URL
-echo "Redirecting to: " . $auth_url . "<br>";
-echo "<a href='" . $auth_url . "'>Click here if not redirected</a>";
-
-// Comment out the redirect temporarily for debugging
-// header('Location: ' . $auth_url);
-// exit;
+// Redirect user to Hootsuite for authorization
+header('Location: ' . $auth_url);
+exit;
 ?>
+


### PR DESCRIPTION
## Summary
- Add settings-backed Hootsuite OAuth entry point
- Show stored access token and add Authenticate button in admin settings

## Testing
- `php -l lib/hootsuite/test_auth.php`
- `php -l admin/settings.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892db61c98c8326b0d8b009da0a1e2d