### PR TITLE
Integrate Hootsuite OAuth into admin settings

### DIFF
--- a/admin/hootsuite_callback.php
+++ b/admin/hootsuite_callback.php
@@ -1,0 +1,54 @@
+<?php
+session_start();
+require_once __DIR__.'/../lib/settings.php';
+
+$client_id = get_setting('hootsuite_client_id');
+$client_secret = get_setting('hootsuite_client_secret');
+$redirect_uri = get_setting('hootsuite_redirect_uri');
+
+if (!isset($_GET['code'])) {
+    exit('Missing authorization code');
+}
+
+$code = $_GET['code'];
+
+$ch = curl_init('https://platform.hootsuite.com/oauth2/token');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_POSTFIELDS => http_build_query([
+        'grant_type' => 'authorization_code',
+        'code' => $code,
+        'redirect_uri' => $redirect_uri,
+        'client_id' => $client_id,
+        'client_secret' => $client_secret,
+    ]),
+]);
+$response = curl_exec($ch);
+if (curl_errno($ch)) {
+    $err = curl_error($ch);
+    curl_close($ch);
+    header('Location: settings.php?hootsuite_token_error=' . urlencode($err) . '&active_tab=calendar');
+    exit;
+}
+curl_close($ch);
+$data = json_decode($response, true);
+$access = $data['access_token'] ?? null;
+$refresh = $data['refresh_token'] ?? null;
+if ($access) {
+    set_setting('hootsuite_access_token', $access);
+    if ($refresh) {
+        set_setting('hootsuite_refresh_token', $refresh);
+    }
+    set_setting('hootsuite_token_last_refresh', date('Y-m-d H:i:s'));
+    $_SESSION['access_token'] = $access;
+    if ($refresh) {
+        $_SESSION['refresh_token'] = $refresh;
+    }
+    header('Location: settings.php?hootsuite_token_saved=1&active_tab=calendar');
+    exit;
+} else {
+    $err = $data['error'] ?? 'Token error';
+    header('Location: settings.php?hootsuite_token_error=' . urlencode($err) . '&active_tab=calendar');
+    exit;
+}

--- a/admin/hootsuite_login.php
+++ b/admin/hootsuite_login.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__.'/../lib/settings.php';
+
+$client_id = get_setting('hootsuite_client_id');
+$redirect_uri = get_setting('hootsuite_redirect_uri');
+
+if (!$client_id || !$redirect_uri) {
+    exit('Hootsuite client ID or redirect URI not configured.');
+}
+
+$params = [
+    'client_id' => $client_id,
+    'redirect_uri' => $redirect_uri,
+    'response_type' => 'code',
+    'scope' => 'offline',
+];
+
+header('Location: https://platform.hootsuite.com/oauth2/auth?' . http_build_query($params));
+exit;

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -9,7 +9,17 @@ $pdo = get_pdo();
 
 $success = false;
 $test_result = null;
-$active_tab = $_POST['active_tab'] ?? 'general';
+$active_tab = $_POST['active_tab'] ?? ($_GET['active_tab'] ?? 'general');
+
+if (isset($_GET['hootsuite_token_saved'])) {
+    $test_result = [true, 'Access token saved'];
+    $test_action = 'hootsuite';
+    $active_tab = 'calendar';
+} elseif (isset($_GET['hootsuite_token_error'])) {
+    $test_result = [false, $_GET['hootsuite_token_error']];
+    $test_action = 'hootsuite';
+    $active_tab = 'calendar';
+}
 
 // Fetch upload statuses
 $statuses = $pdo->query('SELECT id, name, color FROM upload_statuses ORDER BY id')->fetchAll(PDO::FETCH_ASSOC);
@@ -899,7 +909,7 @@ include __DIR__.'/header.php';
                                     <i class="bi bi-arrow-repeat"></i> Hootsuite Actions
                                 </h6>
                                 <div class="d-flex flex-wrap gap-2">
-                                    <a class="btn btn-secondary-modern btn-sm-modern" href="../lib/hootsuite/test_auth.php">
+                                    <a class="btn btn-secondary-modern btn-sm-modern" href="hootsuite_login.php">
                                         <i class="bi bi-box-arrow-in-right"></i> Authenticate
                                     </a>
                                     <button class="btn btn-secondary-modern btn-sm-modern" type="submit" name="test_hootsuite_connection">


### PR DESCRIPTION
## Summary
- Capture Hootsuite OAuth tokens in settings and show success feedback
- Provide admin endpoints to start OAuth flow and handle callback storing tokens

## Testing
- `php -l admin/hootsuite_login.php`
- `php -l admin/hootsuite_callback.php`
- `php -l admin/settings.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892dda680348326a680ca3daf9b54c4