### PR TITLE
Improve Hootsuite sync error handling

### DIFF
--- a/hoot/hootsuite_sync.php
+++ b/hoot/hootsuite_sync.php
@@ -3,64 +3,66 @@ require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/settings.php';
 
 function hootsuite_update(bool $force = false, bool $debug = false): array {
-    $enabled = get_setting('hootsuite_enabled');
-    if ($enabled !== '1') {
-        return [false, 'Hootsuite integration disabled'];
-    }
-    $interval = (int)(get_setting('hootsuite_update_interval') ?: 24);
-    $last = get_setting('hootsuite_last_update');
-    if (!$force && $last && (time() - strtotime($last) < $interval * 3600)) {
-        return [false, 'Update not required yet'];
-    }
-
-    $token = get_setting('hootsuite_access_token');
-    if (!$token) {
-        return [false, 'Missing access token'];
-    }
-
-    $startTime = date('c');
-    $endTime = date('c', strtotime('+28 days'));
-    $params = http_build_query([
-        'state' => 'SCHEDULED',
-        'limit' => 100,
-        'startTime' => $startTime,
-        'endTime' => $endTime,
-    ]);
-    $url = 'https://platform.hootsuite.com/v1/messages?' . $params;
-
-    $messages = [];
-    $page = 0;
-    $max_pages = 10;
-
-    do {
-        $ch = curl_init($url);
-        curl_setopt_array($ch, [
-            CURLOPT_HTTPHEADER => ["Authorization: Bearer $token", 'Content-Type: application/json'],
-            CURLOPT_RETURNTRANSFER => true,
-        ]);
-        $response = curl_exec($ch);
-        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        $curl_error = curl_error($ch);
-        curl_close($ch);
-
-        if ($curl_error) {
-            return [false, 'cURL error: ' . $curl_error];
-        }
-        if ($code !== 200) {
-            return [false, 'API error HTTP ' . $code . ($debug ? ' | ' . $response : '')];
-        }
-
-        $data = json_decode($response, true);
-        $messages = array_merge($messages, $data['data'] ?? []);
-        $url = $data['pagination']['next'] ?? null;
-        $page++;
-    } while ($url && $page < $max_pages);
-
-    $pdo = get_pdo();
     try {
+        $enabled = get_setting('hootsuite_enabled');
+        if ($enabled !== '1') {
+            return [false, 'Hootsuite integration disabled'];
+        }
+        $interval = (int)(get_setting('hootsuite_update_interval') ?: 24);
+        $last = get_setting('hootsuite_last_update');
+        if (!$force && $last && (time() - strtotime($last) < $interval * 3600)) {
+            return [false, 'Update not required yet'];
+        }
+
+        $token = get_setting('hootsuite_access_token');
+        if (!$token) {
+            return [false, 'Missing access token'];
+        }
+
+        $startTime = date('c');
+        $endTime = date('c', strtotime('+28 days'));
+        $params = http_build_query([
+            'state' => 'SCHEDULED',
+            'limit' => 100,
+            'startTime' => $startTime,
+            'endTime' => $endTime,
+        ]);
+        $url = 'https://platform.hootsuite.com/v1/messages?' . $params;
+
+        $messages = [];
+        $page = 0;
+        $max_pages = 10;
+
+        do {
+            $ch = curl_init($url);
+            curl_setopt_array($ch, [
+                CURLOPT_HTTPHEADER => ["Authorization: Bearer $token", 'Content-Type: application/json'],
+                CURLOPT_RETURNTRANSFER => true,
+            ]);
+            $response = curl_exec($ch);
+            $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $curl_error = curl_error($ch);
+            curl_close($ch);
+
+            if ($curl_error) {
+                return [false, 'cURL error: ' . $curl_error];
+            }
+            if ($code !== 200) {
+                return [false, 'API error HTTP ' . $code . ($debug ? ' | ' . $response : '')];
+            }
+
+            $data = json_decode($response, true);
+            $messages = array_merge($messages, $data['data'] ?? []);
+            $url = $data['pagination']['next'] ?? null;
+            $page++;
+        } while ($url && $page < $max_pages);
+
+        $pdo = get_pdo();
         $pdo->beginTransaction();
-        $pdo->exec('TRUNCATE TABLE hootsuite_posts');
-        $stmt = $pdo->prepare('INSERT INTO hootsuite_posts (post_id, store_id, text, scheduled_send_time, raw_json) VALUES (?, ?, ?, ?, ?)');
+        if ($force) {
+            $pdo->exec('TRUNCATE TABLE hootsuite_posts');
+        }
+        $stmt = $pdo->prepare('INSERT INTO hootsuite_posts (post_id, store_id, text, scheduled_send_time, raw_json) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE store_id=VALUES(store_id), text=VALUES(text), scheduled_send_time=VALUES(scheduled_send_time), raw_json=VALUES(raw_json)');
         foreach ($messages as $m) {
             $stmt->execute([
                 $m['id'] ?? '',
@@ -71,17 +73,18 @@ function hootsuite_update(bool $force = false, bool $debug = false): array {
             ]);
         }
         $pdo->commit();
-    } catch (PDOException $e) {
-        $pdo->rollBack();
+        set_setting('hootsuite_last_update', date('Y-m-d H:i:s'));
+        $msg = ($force ? 'Forced' : 'Automatic') . ' Hootsuite sync executed';
+        if ($debug) {
+            $msg .= ' | fetched ' . count($messages) . ' posts';
+        }
+        return [true, $msg];
+    } catch (Throwable $e) {
+        if (isset($pdo) && $pdo instanceof PDO && $pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
         return [false, $e->getMessage()];
     }
-
-    set_setting('hootsuite_last_update', date('Y-m-d H:i:s'));
-    $msg = ($force ? 'Forced' : 'Automatic') . ' Hootsuite sync executed';
-    if ($debug) {
-        $msg .= ' | fetched ' . count($messages) . ' posts';
-    }
-    return [true, $msg];
 }
 
 function hootsuite_erase_all(): array {

--- a/update_database.php
+++ b/update_database.php
@@ -512,7 +512,7 @@ try {
 try {
     $pdo->exec("CREATE TABLE IF NOT EXISTS hootsuite_posts (
         id INT AUTO_INCREMENT PRIMARY KEY,
-        post_id VARCHAR(50) NOT NULL,
+        post_id VARCHAR(50) NOT NULL UNIQUE,
         store_id INT NOT NULL,
         text TEXT,
         scheduled_send_time DATETIME,
@@ -523,6 +523,14 @@ try {
     echo "✓ Created hootsuite_posts table\n";
 } catch (PDOException $e) {
     echo "✗ Error creating hootsuite_posts table: " . $e->getMessage() . "\n";
+}
+
+// Ensure post_id is unique for existing installations
+try {
+    $pdo->exec("ALTER TABLE hootsuite_posts ADD UNIQUE KEY uniq_post_id (post_id)");
+    echo "✓ Added uniq_post_id index\n";
+} catch (PDOException $e) {
+    echo "ℹ︎ Could not add uniq_post_id index: " . $e->getMessage() . "\n";
 }
 
 // Create calendar table


### PR DESCRIPTION
## Summary
- Ensure Sync Now only inserts or updates posts instead of always truncating
- Add error handling and upsert logic to Hootsuite sync
- Create unique index for hootsuite_posts table

## Testing
- `php -l hoot/hootsuite_sync.php`
- `php -l update_database.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68936a5363388326a32732dd35fc9ba2