### PR TITLE
Add Hootsuite profile ID mapping for stores

### DIFF
--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -31,7 +31,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $errors[] = 'PIN already exists';
         } else {
-            $update = $pdo->prepare('UPDATE stores SET name=?, pin=?, admin_email=?, drive_folder=?, hootsuite_token=?, hootsuite_campaign_tag=?, first_name=?, last_name=?, phone=?, address=?, city=?, state=?, zip_code=?, country=?, marketing_report_url=? WHERE id=?');
+            $update = $pdo->prepare('UPDATE stores SET name=?, pin=?, admin_email=?, drive_folder=?, hootsuite_token=?, hootsuite_campaign_tag=?, hootsuite_profile_ids=?, first_name=?, last_name=?, phone=?, address=?, city=?, state=?, zip_code=?, country=?, marketing_report_url=? WHERE id=?');
             $update->execute([
                 $_POST['name'],
                 $_POST['pin'],
@@ -39,6 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $_POST['folder'],
                 $_POST['hootsuite_token'],
                 $_POST['hootsuite_campaign_tag'] ?? null,
+                $_POST['hootsuite_profile_ids'] ?? null,
                 $_POST['first_name'] ?? null,
                 $_POST['last_name'] ?? null,
                 format_mobile_number($_POST['phone'] ?? ''),
@@ -338,6 +339,14 @@ include __DIR__.'/header.php';
                                    placeholder="lowercase, no spaces"
                                    value="<?php echo htmlspecialchars($store['hootsuite_campaign_tag']); ?>">
                             <div class="form-text">Must match the tag in Hootsuite</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="hootsuite_profile_ids" class="form-label-modern">Hootsuite Profile IDs</label>
+                            <input type="text" name="hootsuite_profile_ids" id="hootsuite_profile_ids"
+                                   class="form-control form-control-modern"
+                                   placeholder="comma-separated or JSON"
+                                   value="<?php echo htmlspecialchars($store['hootsuite_profile_ids']); ?>">
+                            <div class="form-text">Comma-separated or JSON array of profile IDs</div>
                         </div>
                         <div class="col-md-12">
                             <label for="marketing_report_url" class="form-label-modern">Marketing Report URL</label>

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -17,13 +17,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $errors[] = 'PIN already exists';
         } else {
-            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_campaign_tag, first_name, last_name, phone, address, city, state, zip_code, country, marketing_report_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_campaign_tag, hootsuite_profile_ids, first_name, last_name, phone, address, city, state, zip_code, country, marketing_report_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
             $stmt->execute([
                 $_POST['name'],
                 $_POST['pin'],
                 $_POST['email'],
                 $_POST['folder'],
                 $_POST['hootsuite_campaign_tag'] ?? null,
+                $_POST['hootsuite_profile_ids'] ?? null,
                 $_POST['first_name'] ?? null,
                 $_POST['last_name'] ?? null,
                 format_mobile_number($_POST['phone'] ?? ''),
@@ -368,6 +369,12 @@ include __DIR__.'/header.php';
                             <label for="hootsuite_campaign_tag" class="form-label-modern">Hootsuite Tag</label>
                             <input type="text" name="hootsuite_campaign_tag" id="hootsuite_campaign_tag"
                                    class="form-control form-control-modern">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="hootsuite_profile_ids" class="form-label-modern">Hootsuite Profile IDs</label>
+                            <input type="text" name="hootsuite_profile_ids" id="hootsuite_profile_ids"
+                                   class="form-control form-control-modern">
+                            <div class="form-text">Comma-separated or JSON array</div>
                         </div>
                         <div class="col-md-12">
                             <label for="marketing_report_url" class="form-label-modern">Marketing Report URL</label>

--- a/cmuploader.sql
+++ b/cmuploader.sql
@@ -560,7 +560,8 @@ CREATE TABLE `stores` (
   `state` varchar(100) DEFAULT NULL,
   `zip_code` varchar(20) DEFAULT NULL,
   `country` varchar(100) DEFAULT NULL,
-  `marketing_report_url` varchar(255) DEFAULT NULL
+  `marketing_report_url` varchar(255) DEFAULT NULL,
+  `hootsuite_profile_ids` text DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --

--- a/setup.php
+++ b/setup.php
@@ -236,6 +236,13 @@ try {
     // Column might already exist
 }
 
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_profile_ids TEXT AFTER hootsuite_campaign_tag");
+    echo "✓ Added hootsuite_profile_ids column to stores table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
 // Additional store contact columns
 try {
     $pdo->exec("ALTER TABLE stores ADD COLUMN first_name VARCHAR(100) AFTER hootsuite_token");

--- a/update_database.php
+++ b/update_database.php
@@ -278,6 +278,13 @@ try {
     echo "• hootsuite_campaign_tag column might already exist\n";
 }
 
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_profile_ids TEXT AFTER hootsuite_campaign_tag");
+    echo "✓ Added hootsuite_profile_ids column to stores table\n";
+} catch (PDOException $e) {
+    echo "• hootsuite_profile_ids column might already exist\n";
+}
+
 // New contact columns for stores
 try {
     $pdo->exec("ALTER TABLE stores ADD COLUMN first_name VARCHAR(100) AFTER hootsuite_token");


### PR DESCRIPTION
## Summary
- allow storing multiple Hootsuite profile IDs per store
- admin can now edit profile IDs alongside existing tag field
- resolve posts to stores via profile IDs before falling back to tags

## Testing
- `php -l admin/edit_store.php`
- `php -l admin/stores.php`
- `php -l hoot/hootsuite_sync.php`
- `php -l lib/calendar.php`
- `php -l setup.php`
- `php -l update_database.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68939cff984c8326ac701d52be2bbe91