### PR TITLE
Add Hootsuite campaign mapping support

### DIFF
--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -31,7 +31,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $errors[] = 'PIN already exists';
         } else {
-            $update = $pdo->prepare('UPDATE stores SET name=?, pin=?, admin_email=?, drive_folder=?, hootsuite_token=?, hootsuite_campaign_tag=?, hootsuite_profile_ids=?, first_name=?, last_name=?, phone=?, address=?, city=?, state=?, zip_code=?, country=?, marketing_report_url=? WHERE id=?');
+            $update = $pdo->prepare('UPDATE stores SET name=?, pin=?, admin_email=?, drive_folder=?, hootsuite_token=?, hootsuite_campaign_tag=?, hootsuite_campaign_id=?, hootsuite_profile_ids=?, first_name=?, last_name=?, phone=?, address=?, city=?, state=?, zip_code=?, country=?, marketing_report_url=? WHERE id=?');
             $update->execute([
                 $_POST['name'],
                 $_POST['pin'],
@@ -39,6 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $_POST['folder'],
                 $_POST['hootsuite_token'],
                 $_POST['hootsuite_campaign_tag'] ?? null,
+                $_POST['hootsuite_campaign_id'] ?? null,
                 $_POST['hootsuite_profile_ids'] ?? null,
                 $_POST['first_name'] ?? null,
                 $_POST['last_name'] ?? null,
@@ -341,6 +342,14 @@ include __DIR__.'/header.php';
                             <div class="form-text">Must match the tag in Hootsuite</div>
                         </div>
                         <div class="col-md-6">
+                            <label for="hootsuite_campaign_id" class="form-label-modern">Hootsuite Campaign ID</label>
+                            <div class="input-group">
+                                <input type="number" name="hootsuite_campaign_id" id="hootsuite_campaign_id" class="form-control form-control-modern" list="campaigns_list" value="<?php echo htmlspecialchars($store['hootsuite_campaign_id']); ?>">
+                                <button class="btn btn-outline-secondary" type="button" id="load_campaigns">Load</button>
+                            </div>
+                            <datalist id="campaigns_list"></datalist>
+                        </div>
+                        <div class="col-md-6">
                             <label for="hootsuite_profile_ids" class="form-label-modern">Hootsuite Profile IDs</label>
                             <input type="text" name="hootsuite_profile_ids" id="hootsuite_profile_ids"
                                    class="form-control form-control-modern"
@@ -459,4 +468,23 @@ include __DIR__.'/header.php';
         </div>
     </div>
 
-<?php include __DIR__.'/footer.php'; ?>
+    <script>
+        document.getElementById('load_campaigns')?.addEventListener('click', function () {
+            fetch('../hoot/hootsuite_campaigns.php')
+                .then(r => r.json())
+                .then(data => {
+                    const list = document.getElementById('campaigns_list');
+                    list.innerHTML = '';
+                    data.forEach(c => {
+                        if (c.id && c.name !== undefined) {
+                            const opt = document.createElement('option');
+                            opt.value = c.id;
+                            opt.textContent = c.name;
+                            list.appendChild(opt);
+                        }
+                    });
+                });
+        });
+    </script>
+
+    <?php include __DIR__.'/footer.php'; ?>

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -17,13 +17,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $errors[] = 'PIN already exists';
         } else {
-            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_campaign_tag, hootsuite_profile_ids, first_name, last_name, phone, address, city, state, zip_code, country, marketing_report_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_campaign_tag, hootsuite_campaign_id, hootsuite_profile_ids, first_name, last_name, phone, address, city, state, zip_code, country, marketing_report_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
             $stmt->execute([
                 $_POST['name'],
                 $_POST['pin'],
                 $_POST['email'],
                 $_POST['folder'],
                 $_POST['hootsuite_campaign_tag'] ?? null,
+                $_POST['hootsuite_campaign_id'] ?? null,
                 $_POST['hootsuite_profile_ids'] ?? null,
                 $_POST['first_name'] ?? null,
                 $_POST['last_name'] ?? null,
@@ -214,6 +215,7 @@ include __DIR__.'/header.php';
                                 <th>PIN</th>
                                 <th>Admin Email</th>
                                 <th>Drive Folder</th>
+                                <th>Campaign ID</th>
                                 <th>Chats</th>
                                 <th>Uploads</th>
                                 <th>Actions</th>
@@ -249,6 +251,9 @@ include __DIR__.'/header.php';
                                         <?php else: ?>
                                             <span class="text-muted">Auto-create</span>
                                         <?php endif; ?>
+                                    </td>
+                                    <td>
+                                        <?php echo htmlspecialchars($s['hootsuite_campaign_id'] ?? ''); ?>
                                     </td>
                                     <td>
                                         <span class="badge bg-info"><?php echo $s['chat_count']; ?></span>
@@ -371,6 +376,14 @@ include __DIR__.'/header.php';
                                    class="form-control form-control-modern">
                         </div>
                         <div class="col-md-6">
+                            <label for="hootsuite_campaign_id" class="form-label-modern">Hootsuite Campaign ID</label>
+                            <div class="input-group">
+                                <input type="number" name="hootsuite_campaign_id" id="hootsuite_campaign_id" class="form-control form-control-modern" list="campaigns_list">
+                                <button class="btn btn-outline-secondary" type="button" id="load_campaigns">Load</button>
+                            </div>
+                            <datalist id="campaigns_list"></datalist>
+                        </div>
+                        <div class="col-md-6">
                             <label for="hootsuite_profile_ids" class="form-label-modern">Hootsuite Profile IDs</label>
                             <input type="text" name="hootsuite_profile_ids" id="hootsuite_profile_ids"
                                    class="form-control form-control-modern">
@@ -392,5 +405,24 @@ include __DIR__.'/header.php';
             </form>
         </div>
     </div>
+
+    <script>
+        document.getElementById('load_campaigns')?.addEventListener('click', function () {
+            fetch('../hoot/hootsuite_campaigns.php')
+                .then(r => r.json())
+                .then(data => {
+                    const list = document.getElementById('campaigns_list');
+                    list.innerHTML = '';
+                    data.forEach(c => {
+                        if (c.id && c.name !== undefined) {
+                            const opt = document.createElement('option');
+                            opt.value = c.id;
+                            opt.textContent = c.name;
+                            list.appendChild(opt);
+                        }
+                    });
+                });
+        });
+    </script>
 
 <?php include __DIR__.'/footer.php'; ?>

--- a/cmuploader.sql
+++ b/cmuploader.sql
@@ -552,6 +552,7 @@ CREATE TABLE `stores` (
   `drive_folder` varchar(255) DEFAULT NULL,
   `hootsuite_token` varchar(255) DEFAULT NULL,
   `hootsuite_campaign_tag` varchar(100) DEFAULT NULL,
+  `hootsuite_campaign_id` bigint DEFAULT NULL,
   `first_name` varchar(100) DEFAULT NULL,
   `last_name` varchar(100) DEFAULT NULL,
   `phone` varchar(50) DEFAULT NULL,

--- a/hoot/hootsuite_api.php
+++ b/hoot/hootsuite_api.php
@@ -31,3 +31,32 @@ function hootsuite_get_social_profiles(?string $token): array {
     } while ($url && $page < $max_pages);
     return $profiles;
 }
+
+function hootsuite_get_campaigns(?string $token): array {
+    if (!$token) {
+        return [];
+    }
+    $campaigns = [];
+    $url = 'https://platform.hootsuite.com/v1/campaigns?limit=100';
+    $page = 0;
+    $max_pages = 10;
+    do {
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_HTTPHEADER => ["Authorization: Bearer $token", 'Content-Type: application/json'],
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+        $response = curl_exec($ch);
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curl_error = curl_error($ch);
+        curl_close($ch);
+        if ($curl_error || $code !== 200) {
+            break;
+        }
+        $data = json_decode($response, true);
+        $campaigns = array_merge($campaigns, $data['data'] ?? []);
+        $url = $data['pagination']['next'] ?? null;
+        $page++;
+    } while ($url && $page < $max_pages);
+    return $campaigns;
+}

--- a/hoot/hootsuite_campaigns.php
+++ b/hoot/hootsuite_campaigns.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__.'/../lib/settings.php';
+require_once __DIR__.'/hootsuite_api.php';
+header('Content-Type: application/json');
+$token = get_setting('hootsuite_access_token');
+if (!$token) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Missing access token']);
+    exit;
+}
+$campaigns = hootsuite_get_campaigns($token);
+$out = [];
+foreach ($campaigns as $c) {
+    $out[] = [
+        'id' => $c['id'] ?? null,
+        'name' => $c['name'] ?? ''
+    ];
+}
+echo json_encode($out);
+

--- a/hoot/hootsuite_sync.php
+++ b/hoot/hootsuite_sync.php
@@ -210,12 +210,15 @@ function hootsuite_update(bool $force = false, bool $debug = false): array {
         }
 
         $storeMap = [];
-        $storeMap = [];
         $profileMap = [];
-        foreach ($pdo->query('SELECT id, hootsuite_campaign_tag, hootsuite_profile_ids FROM stores') as $row) {
+        $campaignMap = [];
+        foreach ($pdo->query('SELECT id, hootsuite_campaign_tag, hootsuite_campaign_id, hootsuite_profile_ids FROM stores') as $row) {
             $norm = normalize_tag($row['hootsuite_campaign_tag'] ?? '');
             if ($norm !== '') {
                 $storeMap[$norm] = (int)$row['id'];
+            }
+            if (!empty($row['hootsuite_campaign_id'])) {
+                $campaignMap[(string)$row['hootsuite_campaign_id']] = (int)$row['id'];
             }
             foreach (to_string_array($row['hootsuite_profile_ids'] ?? null) as $pid) {
                 $profileMap[$pid] = (int)$row['id'];
@@ -253,6 +256,13 @@ function hootsuite_update(bool $force = false, bool $debug = false): array {
             $store_id = null;
             foreach ($profileIds as $pid) {
                 if (isset($profileMap[$pid])) { $store_id = $profileMap[$pid]; break; }
+            }
+
+            $campaignIds = to_string_array($m['campaignIds'] ?? null);
+            if (!$store_id) {
+                foreach ($campaignIds as $cid) {
+                    if (isset($campaignMap[$cid])) { $store_id = $campaignMap[$cid]; break; }
+                }
             }
 
             $tags = $m['tags'] ?? [];

--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -222,10 +222,14 @@ function calendar_update(bool $force = false): array {
     $inserted = 0;
     $storeMap = [];
     $profileMap = [];
-    foreach ($pdo->query('SELECT id, hootsuite_campaign_tag, hootsuite_profile_ids FROM stores') as $row) {
+    $campaignMap = [];
+    foreach ($pdo->query('SELECT id, hootsuite_campaign_tag, hootsuite_campaign_id, hootsuite_profile_ids FROM stores') as $row) {
         $norm = normalize_tag($row['hootsuite_campaign_tag'] ?? '');
         if ($norm !== '') {
             $storeMap[$norm] = (int)$row['id'];
+        }
+        if (!empty($row['hootsuite_campaign_id'])) {
+            $campaignMap[(string)$row['hootsuite_campaign_id']] = (int)$row['id'];
         }
         foreach (to_string_array($row['hootsuite_profile_ids'] ?? null) as $pid) {
             $profileMap[$pid] = (int)$row['id'];
@@ -259,6 +263,13 @@ function calendar_update(bool $force = false): array {
         $store_id = null;
         foreach ($profileIds as $pid) {
             if (isset($profileMap[$pid])) { $store_id = $profileMap[$pid]; break; }
+        }
+
+        $campaignIds = to_string_array($post['campaignIds'] ?? null);
+        if (!$store_id) {
+            foreach ($campaignIds as $cid) {
+                if (isset($campaignMap[$cid])) { $store_id = $campaignMap[$cid]; break; }
+            }
         }
 
         $tags = $post['tags'] ?? [];

--- a/setup.php
+++ b/setup.php
@@ -22,6 +22,7 @@ $queries = [
         drive_folder VARCHAR(255),
         hootsuite_token VARCHAR(255),
         hootsuite_campaign_tag VARCHAR(100),
+        hootsuite_campaign_id BIGINT,
         first_name VARCHAR(100),
         last_name VARCHAR(100),
         phone VARCHAR(50),
@@ -237,7 +238,14 @@ try {
 }
 
 try {
-    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_profile_ids TEXT AFTER hootsuite_campaign_tag");
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_campaign_id BIGINT AFTER hootsuite_campaign_tag");
+    echo "✓ Added hootsuite_campaign_id column to stores table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_profile_ids TEXT AFTER hootsuite_campaign_id");
     echo "✓ Added hootsuite_profile_ids column to stores table\n";
 } catch (PDOException $e) {
     // Column might already exist

--- a/update_database.php
+++ b/update_database.php
@@ -279,7 +279,14 @@ try {
 }
 
 try {
-    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_profile_ids TEXT AFTER hootsuite_campaign_tag");
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_campaign_id BIGINT AFTER hootsuite_campaign_tag");
+    echo "✓ Added hootsuite_campaign_id column to stores table\n";
+} catch (PDOException $e) {
+    echo "• hootsuite_campaign_id column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_profile_ids TEXT AFTER hootsuite_campaign_id");
     echo "✓ Added hootsuite_profile_ids column to stores table\n";
 } catch (PDOException $e) {
     echo "• hootsuite_profile_ids column might already exist\n";


### PR DESCRIPTION
## Summary
- add `hootsuite_campaign_id` column and migrations
- match Hootsuite posts using campaign IDs during sync and calendar import
- allow admins to select campaign IDs using the Hootsuite Campaigns API

## Testing
- `php -l admin/edit_store.php`
- `php -l admin/stores.php`
- `php -l hoot/hootsuite_api.php`
- `php -l hoot/hootsuite_sync.php`
- `php -l lib/calendar.php`
- `php -l setup.php`
- `php -l update_database.php`
- `php -l hoot/hootsuite_campaigns.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68939f9b60b0832694c392ecf3be7339