### PR TITLE
Map Hootsuite posts to stores via custom property

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ To debug Google Drive uploads, check **Drive Debug Logging** under **Admin → S
 
 To populate the calendar from Google Sheets, open **Admin → Settings** and paste the sheet's public URL in the **Google Sheet URL** field. The application automatically converts the standard editing link into the required CSV export format.
 
+### Hootsuite Custom Properties
+
+Stores can be matched to scheduled Hootsuite posts using custom properties. In the store editor, configure the **Hootsuite Custom Property Key** and **Value** fields. When scheduling content in Hootsuite, add a custom property with the same key/value pair (e.g. `store_id:123`). During sync, posts containing this property will be automatically associated with the matching store.
+
 ## Recent Improvements
 
 Recent releases introduced several enhancements:

--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -31,7 +31,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $errors[] = 'PIN already exists';
         } else {
-            $update = $pdo->prepare('UPDATE stores SET name=?, pin=?, admin_email=?, drive_folder=?, hootsuite_token=?, hootsuite_campaign_tag=?, hootsuite_campaign_id=?, hootsuite_profile_ids=?, first_name=?, last_name=?, phone=?, address=?, city=?, state=?, zip_code=?, country=?, marketing_report_url=? WHERE id=?');
+            $update = $pdo->prepare('UPDATE stores SET name=?, pin=?, admin_email=?, drive_folder=?, hootsuite_token=?, hootsuite_campaign_tag=?, hootsuite_campaign_id=?, hootsuite_profile_ids=?, hootsuite_custom_property_key=?, hootsuite_custom_property_value=?, first_name=?, last_name=?, phone=?, address=?, city=?, state=?, zip_code=?, country=?, marketing_report_url=? WHERE id=?');
             $update->execute([
                 $_POST['name'],
                 $_POST['pin'],
@@ -41,6 +41,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $_POST['hootsuite_campaign_tag'] ?? null,
                 $_POST['hootsuite_campaign_id'] ?? null,
                 $_POST['hootsuite_profile_ids'] ?? null,
+                $_POST['hootsuite_custom_property_key'] ?? null,
+                $_POST['hootsuite_custom_property_value'] ?? null,
                 $_POST['first_name'] ?? null,
                 $_POST['last_name'] ?? null,
                 format_mobile_number($_POST['phone'] ?? ''),
@@ -356,6 +358,20 @@ include __DIR__.'/header.php';
                                    placeholder="comma-separated or JSON"
                                    value="<?php echo htmlspecialchars($store['hootsuite_profile_ids']); ?>">
                             <div class="form-text">Comma-separated or JSON array of profile IDs</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="hootsuite_custom_property_key" class="form-label-modern">Hootsuite Custom Property Key</label>
+                            <input type="text" name="hootsuite_custom_property_key" id="hootsuite_custom_property_key"
+                                   class="form-control form-control-modern"
+                                   value="<?php echo htmlspecialchars($store['hootsuite_custom_property_key']); ?>">
+                            <div class="form-text">Custom property name to match</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="hootsuite_custom_property_value" class="form-label-modern">Hootsuite Custom Property Value</label>
+                            <input type="text" name="hootsuite_custom_property_value" id="hootsuite_custom_property_value"
+                                   class="form-control form-control-modern"
+                                   value="<?php echo htmlspecialchars($store['hootsuite_custom_property_value']); ?>">
+                            <div class="form-text">Required value for the custom property</div>
                         </div>
                         <div class="col-md-12">
                             <label for="marketing_report_url" class="form-label-modern">Marketing Report URL</label>

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -17,7 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $errors[] = 'PIN already exists';
         } else {
-            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_campaign_tag, hootsuite_campaign_id, hootsuite_profile_ids, first_name, last_name, phone, address, city, state, zip_code, country, marketing_report_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+            $stmt = $pdo->prepare('INSERT INTO stores (name, pin, admin_email, drive_folder, hootsuite_campaign_tag, hootsuite_campaign_id, hootsuite_profile_ids, hootsuite_custom_property_key, hootsuite_custom_property_value, first_name, last_name, phone, address, city, state, zip_code, country, marketing_report_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
             $stmt->execute([
                 $_POST['name'],
                 $_POST['pin'],
@@ -26,6 +26,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $_POST['hootsuite_campaign_tag'] ?? null,
                 $_POST['hootsuite_campaign_id'] ?? null,
                 $_POST['hootsuite_profile_ids'] ?? null,
+                $_POST['hootsuite_custom_property_key'] ?? null,
+                $_POST['hootsuite_custom_property_value'] ?? null,
                 $_POST['first_name'] ?? null,
                 $_POST['last_name'] ?? null,
                 format_mobile_number($_POST['phone'] ?? ''),
@@ -388,6 +390,14 @@ include __DIR__.'/header.php';
                             <input type="text" name="hootsuite_profile_ids" id="hootsuite_profile_ids"
                                    class="form-control form-control-modern">
                             <div class="form-text">Comma-separated or JSON array</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="hootsuite_custom_property_key" class="form-label-modern">Hootsuite Custom Property Key</label>
+                            <input type="text" name="hootsuite_custom_property_key" id="hootsuite_custom_property_key" class="form-control form-control-modern">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="hootsuite_custom_property_value" class="form-label-modern">Hootsuite Custom Property Value</label>
+                            <input type="text" name="hootsuite_custom_property_value" id="hootsuite_custom_property_value" class="form-control form-control-modern">
                         </div>
                         <div class="col-md-12">
                             <label for="marketing_report_url" class="form-label-modern">Marketing Report URL</label>

--- a/cmuploader.sql
+++ b/cmuploader.sql
@@ -562,7 +562,9 @@ CREATE TABLE `stores` (
   `zip_code` varchar(20) DEFAULT NULL,
   `country` varchar(100) DEFAULT NULL,
   `marketing_report_url` varchar(255) DEFAULT NULL,
-  `hootsuite_profile_ids` text DEFAULT NULL
+  `hootsuite_profile_ids` text DEFAULT NULL,
+  `hootsuite_custom_property_key` varchar(100) DEFAULT NULL,
+  `hootsuite_custom_property_value` varchar(100) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --

--- a/hoot/hootsuite_sync.php
+++ b/hoot/hootsuite_sync.php
@@ -212,7 +212,8 @@ function hootsuite_update(bool $force = false, bool $debug = false): array {
         $storeMap = [];
         $profileMap = [];
         $campaignMap = [];
-        foreach ($pdo->query('SELECT id, hootsuite_campaign_tag, hootsuite_campaign_id, hootsuite_profile_ids FROM stores') as $row) {
+        $propMap = [];
+        foreach ($pdo->query('SELECT id, hootsuite_campaign_tag, hootsuite_campaign_id, hootsuite_profile_ids, hootsuite_custom_property_key, hootsuite_custom_property_value FROM stores') as $row) {
             $norm = normalize_tag($row['hootsuite_campaign_tag'] ?? '');
             if ($norm !== '') {
                 $storeMap[$norm] = (int)$row['id'];
@@ -222,6 +223,12 @@ function hootsuite_update(bool $force = false, bool $debug = false): array {
             }
             foreach (to_string_array($row['hootsuite_profile_ids'] ?? null) as $pid) {
                 $profileMap[$pid] = (int)$row['id'];
+            }
+            $ckey = $row['hootsuite_custom_property_key'] ?? null;
+            $cval = $row['hootsuite_custom_property_value'] ?? null;
+            if ($ckey && $cval) {
+                if (!isset($propMap[$ckey])) { $propMap[$ckey] = []; }
+                $propMap[$ckey][$cval] = (int)$row['id'];
             }
         }
 
@@ -262,6 +269,15 @@ function hootsuite_update(bool $force = false, bool $debug = false): array {
             if (!$store_id) {
                 foreach ($campaignIds as $cid) {
                     if (isset($campaignMap[$cid])) { $store_id = $campaignMap[$cid]; break; }
+                }
+            }
+
+            $customProps = $m['customProperties'] ?? [];
+            if (!$store_id && is_array($customProps)) {
+                foreach ($customProps as $prop) {
+                    $pk = $prop['key'] ?? $prop['name'] ?? null;
+                    $pv = $prop['value'] ?? null;
+                    if ($pk !== null && $pv !== null && isset($propMap[$pk][$pv])) { $store_id = $propMap[$pk][$pv]; break; }
                 }
             }
 

--- a/setup.php
+++ b/setup.php
@@ -251,6 +251,20 @@ try {
     // Column might already exist
 }
 
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_custom_property_key VARCHAR(100) AFTER hootsuite_profile_ids");
+    echo "✓ Added hootsuite_custom_property_key column to stores table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_custom_property_value VARCHAR(100) AFTER hootsuite_custom_property_key");
+    echo "✓ Added hootsuite_custom_property_value column to stores table\n";
+} catch (PDOException $e) {
+    // Column might already exist
+}
+
 // Additional store contact columns
 try {
     $pdo->exec("ALTER TABLE stores ADD COLUMN first_name VARCHAR(100) AFTER hootsuite_token");

--- a/update_database.php
+++ b/update_database.php
@@ -292,6 +292,20 @@ try {
     echo "• hootsuite_profile_ids column might already exist\n";
 }
 
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_custom_property_key VARCHAR(100) AFTER hootsuite_profile_ids");
+    echo "✓ Added hootsuite_custom_property_key column to stores table\n";
+} catch (PDOException $e) {
+    echo "• hootsuite_custom_property_key column might already exist\n";
+}
+
+try {
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_custom_property_value VARCHAR(100) AFTER hootsuite_custom_property_key");
+    echo "✓ Added hootsuite_custom_property_value column to stores table\n";
+} catch (PDOException $e) {
+    echo "• hootsuite_custom_property_value column might already exist\n";
+}
+
 // New contact columns for stores
 try {
     $pdo->exec("ALTER TABLE stores ADD COLUMN first_name VARCHAR(100) AFTER hootsuite_token");


### PR DESCRIPTION
## Summary
- allow stores to define a custom property key/value used for Hootsuite sync
- inspect Hootsuite post `customProperties` to resolve store matches
- document how to embed store IDs in Hootsuite custom properties

## Testing
- `php -l update_database.php`
- `php -l admin/edit_store.php`
- `php -l admin/stores.php`
- `php -l hoot/hootsuite_sync.php`
- `php -l lib/calendar.php`
- `php -l setup.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_6893a4c27ff88326bd28cb18032695cd