### PR TITLE
Add campaign IDs to Hootsuite tables

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -148,6 +148,7 @@ $queries = [
         text TEXT,
         scheduled_send_time DATETIME,
         social_profile_id VARCHAR(50),
+        campaign_ids TEXT,
         media_urls TEXT,
         media_thumb_urls TEXT,
         media TEXT,

--- a/update_database.php
+++ b/update_database.php
@@ -550,6 +550,7 @@ try {
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         state VARCHAR(50),
         social_profile_id VARCHAR(50),
+        campaign_ids TEXT,
         media_urls TEXT,
         media_thumb_urls TEXT,
         media TEXT,
@@ -578,6 +579,7 @@ try {
 $hootColumns = [
     'state VARCHAR(50)',
     'social_profile_id VARCHAR(50)',
+    'campaign_ids TEXT',
     'media_urls TEXT',
     'media_thumb_urls TEXT',
     'media TEXT',
@@ -618,6 +620,7 @@ try {
         text TEXT,
         scheduled_send_time DATETIME,
         social_profile_id VARCHAR(50),
+        campaign_ids TEXT,
         media_urls TEXT,
         media_thumb_urls TEXT,
         media TEXT,
@@ -664,6 +667,7 @@ try {
 $calendarColumns = [
     'state VARCHAR(50)',
     'social_profile_id VARCHAR(50)',
+    'campaign_ids TEXT',
     'media_urls TEXT',
     'media_thumb_urls TEXT',
     'media TEXT',


### PR DESCRIPTION
## Summary
- store campaign IDs for each Hootsuite post to support reliable store resolution
- include campaign IDs in calendar records and setup script

## Testing
- `php -l update_database.php`
- `php -l setup.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893b4862fd883269f7dc06422dd1f95