### PR TITLE
Improve Hootsuite selectors

### DIFF
--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -489,7 +489,7 @@ include __DIR__.'/header.php';
     </div>
 
     <script>
-        document.getElementById('load_campaigns')?.addEventListener('click', function () {
+        function loadCampaigns() {
             fetch('../hoot/hootsuite_campaigns.php')
                 .then(r => r.json())
                 .then(data => {
@@ -504,7 +504,11 @@ include __DIR__.'/header.php';
                         }
                     });
                 });
-        });
+        }
+
+        document.getElementById('load_campaigns')?.addEventListener('click', loadCampaigns);
+        // Load campaigns on page load for convenience
+        loadCampaigns();
 
         fetch('../hoot/hootsuite_profiles.php')
             .then(r => r.json())

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -422,7 +422,7 @@ include __DIR__.'/header.php';
     </div>
 
     <script>
-        document.getElementById('load_campaigns')?.addEventListener('click', function () {
+        function loadCampaigns() {
             fetch('../hoot/hootsuite_campaigns.php')
                 .then(r => r.json())
                 .then(data => {
@@ -437,7 +437,11 @@ include __DIR__.'/header.php';
                         }
                     });
                 });
-        });
+        }
+
+        document.getElementById('load_campaigns')?.addEventListener('click', loadCampaigns);
+        // Load campaigns on page load for convenience
+        loadCampaigns();
 
         fetch('../hoot/hootsuite_profiles.php')
             .then(r => r.json())

--- a/hoot/hootsuite_profiles.php
+++ b/hoot/hootsuite_profiles.php
@@ -11,9 +11,12 @@ if (!$token) {
 $profiles = hootsuite_get_social_profiles($token);
 $out = [];
 foreach ($profiles as $p) {
+    $username = $p['socialNetworkUsername'] ?? '';
+    $type = $p['type'] ?? '';
+    $label = trim($username) !== '' ? $username . ' (' . $type . ')' : $type;
     $out[] = [
         'id' => $p['id'] ?? null,
-        'name' => $p['type'] ?? ''
+        'name' => $label
     ];
 }
 echo json_encode($out);


### PR DESCRIPTION
## Summary
- Show social profile usernames alongside type so Hootsuite profile picker is meaningful
- Automatically load Hootsuite campaigns on store add/edit pages for easier selection

## Testing
- `php -l cm-storeuploader/hoot/hootsuite_profiles.php`
- `php -l cm-storeuploader/admin/edit_store.php`
- `php -l cm-storeuploader/admin/stores.php`
- `php cm-storeuploader/tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_6893b7ebdf8c8326b6482adf6396873a