### PR TITLE
Add search for Hootsuite profile selection

### DIFF
--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -358,6 +358,7 @@ include __DIR__.'/header.php';
                         </div>
                         <div class="col-md-6">
                             <label for="hootsuite_profile_ids" class="form-label-modern">Hootsuite Profiles</label>
+                            <input type="text" id="hootsuite_profile_search" class="form-control form-control-modern mb-2" placeholder="Search profiles">
                             <select name="hootsuite_profile_ids[]" id="hootsuite_profile_ids" multiple
                                     class="form-select form-select-modern"
                                     data-selected="<?php echo htmlspecialchars($store['hootsuite_profile_ids']); ?>"></select>
@@ -514,6 +515,7 @@ include __DIR__.'/header.php';
             .then(r => r.json())
             .then(data => {
                 const select = document.getElementById('hootsuite_profile_ids');
+                const search = document.getElementById('hootsuite_profile_search');
                 const selected = (select.dataset.selected || '').split(',').map(s => s.trim()).filter(Boolean);
                 data.forEach(p => {
                     if (p.id && p.name !== undefined) {
@@ -525,6 +527,13 @@ include __DIR__.'/header.php';
                         }
                         select.appendChild(opt);
                     }
+                });
+
+                search.addEventListener('input', () => {
+                    const term = search.value.toLowerCase();
+                    Array.from(select.options).forEach(opt => {
+                        opt.style.display = opt.textContent.toLowerCase().includes(term) ? '' : 'none';
+                    });
                 });
             });
     </script>


### PR DESCRIPTION
## Summary
- add text input above profile selector on edit store page
- filter options as user types to quickly find Hootsuite profiles

## Testing
- `php -l admin/edit_store.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893ba1af7048326929f3e8aaa0f7bf5