### PR TITLE
Handle empty Hootsuite campaign id

### DIFF
--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -36,6 +36,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $profile_ids = implode(',', to_string_array($_POST['hootsuite_profile_ids']));
                 if ($profile_ids === '') $profile_ids = null;
             }
+            $campaign_id = $_POST['hootsuite_campaign_id'] ?? null;
+            if ($campaign_id === '') $campaign_id = null;
             $update = $pdo->prepare('UPDATE stores SET name=?, pin=?, admin_email=?, drive_folder=?, hootsuite_token=?, hootsuite_campaign_tag=?, hootsuite_campaign_id=?, hootsuite_profile_ids=?, hootsuite_custom_property_key=?, hootsuite_custom_property_value=?, first_name=?, last_name=?, phone=?, address=?, city=?, state=?, zip_code=?, country=?, marketing_report_url=? WHERE id=?');
             $update->execute([
                 $_POST['name'],
@@ -44,7 +46,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $_POST['folder'],
                 $_POST['hootsuite_token'],
                 $_POST['hootsuite_campaign_tag'] ?? null,
-                $_POST['hootsuite_campaign_id'] ?? null,
+                $campaign_id,
                 $profile_ids,
                 $_POST['hootsuite_custom_property_key'] ?? null,
                 $_POST['hootsuite_custom_property_value'] ?? null,

--- a/update_database.php
+++ b/update_database.php
@@ -279,10 +279,16 @@ try {
 }
 
 try {
-    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_campaign_id BIGINT AFTER hootsuite_campaign_tag");
+    $pdo->exec("ALTER TABLE stores ADD COLUMN hootsuite_campaign_id BIGINT NULL AFTER hootsuite_campaign_tag");
     echo "✓ Added hootsuite_campaign_id column to stores table\n";
 } catch (PDOException $e) {
     echo "• hootsuite_campaign_id column might already exist\n";
+}
+try {
+    $pdo->exec("ALTER TABLE stores MODIFY hootsuite_campaign_id BIGINT NULL");
+    echo "✓ Ensured hootsuite_campaign_id column allows NULL\n";
+} catch (PDOException $e) {
+    echo "• Could not modify hootsuite_campaign_id column: " . $e->getMessage() . "\n";
 }
 
 try {


### PR DESCRIPTION
## Summary
- Avoid SQL errors when Hootsuite campaign ID is left blank on store edit
- Ensure database update script creates and relaxes `hootsuite_campaign_id` column

## Testing
- `php -l admin/edit_store.php`
- `php -l update_database.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893bbb94c6c8326a480add159ba2347