### PR TITLE
Ensure calendar settings are added by update script

### DIFF
--- a/update_database.php
+++ b/update_database.php
@@ -47,6 +47,28 @@ foreach ($newGhSettings as $setting) {
     }
 }
 
+// Ensure calendar and Hootsuite display settings exist
+$calendarSettings = [
+    'calendar_enabled' => '0',
+    'calendar_display_customer' => '0',
+    'hootsuite_enabled' => '0',
+    'hootsuite_display_customer' => '1'
+];
+foreach ($calendarSettings as $name => $value) {
+    try {
+        $stmt = $pdo->prepare("SELECT COUNT(*) FROM settings WHERE name = ?");
+        $stmt->execute([$name]);
+        if (!$stmt->fetchColumn()) {
+            $pdo->prepare("INSERT INTO settings (name, value) VALUES (?, ?)")->execute([$name, $value]);
+            echo "✓ Added setting $name\n";
+        } else {
+            echo "• Setting already exists: $name\n";
+        }
+    } catch (PDOException $e) {
+        echo "✗ Error adding setting $name: " . $e->getMessage() . "\n";
+    }
+}
+
 // Default email settings to add
 $defaultSettings = [
     'email_from_name' => 'Cosmick Media',
@@ -65,10 +87,6 @@ $defaultSettings = [
     'calendar_sheet_range' => 'Sheet1!A:A',
     'calendar_update_interval' => '24',
     'calendar_last_update' => '',
-    'calendar_enabled' => '0',
-    'calendar_display_customer' => '1',
-    'hootsuite_enabled' => '0',
-    'hootsuite_display_customer' => '1',
     'hootsuite_update_interval' => '24',
     'hootsuite_client_id' => '',
     'hootsuite_client_secret' => '',


### PR DESCRIPTION
## Summary
- ensure calendar and Hootsuite display settings are inserted if missing
- remove duplicated calendar and Hootsuite settings from default list

## Testing
- `php -l update_database.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893bf49a07483269974df1c8c2be5b3