### PR TITLE
Disable caching for calendar page

### DIFF
--- a/public/calendar.php
+++ b/public/calendar.php
@@ -12,6 +12,11 @@ if (!isset($_SESSION['store_id'])) {
     exit;
 }
 
+// Disable caching to ensure the calendar is always up to date
+header('Cache-Control: no-cache, no-store, must-revalidate');
+header('Pragma: no-cache');
+header('Expires: 0');
+
 $store_id = $_SESSION['store_id'];
 $pdo = get_pdo();
 


### PR DESCRIPTION
## Summary
- prevent browser caching for the calendar page so updates are always fetched on refresh

## Testing
- `php -l public/calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_6893c88a305083268d541868aebc70c8