### PR TITLE
Cache Hootsuite profiles and link posts to network

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -243,6 +243,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (get_setting('hootsuite_enabled') === '1') {
             require_once __DIR__.'/../hoot/hootsuite_refresh_token.php';
             [$ok, $msg] = hootsuite_refresh_token(get_setting('hootsuite_debug') === '1');
+            if ($ok) {
+                require_once __DIR__.'/../hoot/hootsuite_profiles_sync.php';
+                hootsuite_update_profiles(get_setting('hootsuite_debug') === '1');
+            }
+        } else {
+            [$ok, $msg] = [false, 'Hootsuite integration disabled'];
+        }
+        $test_result = [$ok, $msg];
+        $test_action = 'hootsuite';
+        $active_tab = 'calendar';
+    } elseif (isset($_POST['update_hootsuite_profiles'])) {
+        if (get_setting('hootsuite_enabled') === '1') {
+            require_once __DIR__.'/../hoot/hootsuite_profiles_sync.php';
+            [$ok, $msg] = hootsuite_update_profiles(get_setting('hootsuite_debug') === '1');
         } else {
             [$ok, $msg] = [false, 'Hootsuite integration disabled'];
         }
@@ -948,6 +962,9 @@ include __DIR__.'/header.php';
                                     </button>
                                     <button class="btn btn-secondary-modern btn-sm-modern" type="submit" name="refresh_hootsuite_token">
                                         <i class="bi bi-arrow-clockwise"></i> Refresh Token
+                                    </button>
+                                    <button class="btn btn-secondary-modern btn-sm-modern" type="submit" name="update_hootsuite_profiles">
+                                        <i class="bi bi-people"></i> Refresh Profiles
                                     </button>
                                 </div>
                                 <div class="form-text-modern mt-2">

--- a/cmuploader.sql
+++ b/cmuploader.sql
@@ -179,6 +179,21 @@ CREATE TABLE `hootsuite_posts` (
   `campaign_ids` text DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `hootsuite_profiles`
+--
+
+CREATE TABLE `hootsuite_profiles` (
+  `id` varchar(50) NOT NULL,
+  `type` varchar(100) DEFAULT NULL,
+  `username` varchar(255) DEFAULT NULL,
+  `network` varchar(50) DEFAULT NULL,
+  `raw` text DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 --
 -- Dumping data for table `hootsuite_posts`
 --
@@ -895,7 +910,8 @@ ALTER TABLE `calendar`
 ALTER TABLE `hootsuite_posts`
   ADD PRIMARY KEY (`id`),
   ADD UNIQUE KEY `uniq_post_id` (`post_id`),
-  ADD KEY `idx_store_time` (`store_id`,`scheduled_send_time`);
+  ADD KEY `idx_store_time` (`store_id`,`scheduled_send_time`),
+  ADD CONSTRAINT `fk_hootsuite_profile` FOREIGN KEY (`social_profile_id`) REFERENCES `hootsuite_profiles` (`id`);
 
 --
 -- Indexes for table `logs`

--- a/hoot/hootsuite_profiles_cron.php
+++ b/hoot/hootsuite_profiles_cron.php
@@ -1,0 +1,7 @@
+<?php
+require_once __DIR__.'/hootsuite_profiles_sync.php';
+[$ok, $msg] = hootsuite_update_profiles(false);
+if (!$ok) {
+    error_log('Hootsuite profile update failed: '.$msg);
+}
+?>

--- a/hoot/hootsuite_profiles_sync.php
+++ b/hoot/hootsuite_profiles_sync.php
@@ -1,0 +1,62 @@
+<?php
+require_once __DIR__.'/../lib/db.php';
+require_once __DIR__.'/../lib/settings.php';
+require_once __DIR__.'/hootsuite_api.php';
+
+function hootsuite_profiles_ensure_schema(PDO $pdo): void {
+    $pdo->exec('CREATE TABLE IF NOT EXISTS hootsuite_profiles (
+        id VARCHAR(50) PRIMARY KEY,
+        type VARCHAR(100) NULL,
+        username VARCHAR(255) NULL,
+        network VARCHAR(50) NULL,
+        raw TEXT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+}
+
+function hootsuite_update_profiles(bool $debug = false): array {
+    $token = get_setting('hootsuite_access_token');
+    if (!$token) {
+        return [false, 'Missing access token'];
+    }
+    $profiles = hootsuite_get_social_profiles($token);
+    $pdo = get_pdo();
+    hootsuite_profiles_ensure_schema($pdo);
+
+    $type_map = [
+        'facebookpage'      => 'facebook',
+        'instagrambusiness' => 'instagram',
+        'threads'           => 'threads',
+        'youtubechannel'    => 'youtube',
+        'pinterest'         => 'pinterest',
+        'twitter'           => 'x',
+        'linkedincompany'   => 'linkedin',
+        'tiktokbusiness'    => 'tiktok',
+    ];
+
+    try {
+        $pdo->beginTransaction();
+        $pdo->exec('TRUNCATE TABLE hootsuite_profiles');
+        $stmt = $pdo->prepare('INSERT INTO hootsuite_profiles (id, type, username, network, raw) VALUES (?, ?, ?, ?, ?)');
+        foreach ($profiles as $p) {
+            $id = $p['id'] ?? null;
+            if (!$id) continue;
+            $type = strtolower($p['type'] ?? '');
+            $username = $p['socialNetworkUsername'] ?? '';
+            $network = $type_map[$type] ?? null;
+            $raw = json_encode($p);
+            $stmt->execute([$id, $type, $username, $network, $raw]);
+        }
+        $pdo->commit();
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        if ($debug) {
+            return [false, 'DB Error: '.$e->getMessage()];
+        }
+        return [false, 'Failed to update profiles'];
+    }
+
+    return [true, 'Updated '.count($profiles).' profiles'];
+}
+?>

--- a/hoot/hootsuite_sync.php
+++ b/hoot/hootsuite_sync.php
@@ -3,11 +3,12 @@ require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/settings.php';
 require_once __DIR__.'/../lib/config.php';
 require_once __DIR__.'/../lib/helpers.php';
+require_once __DIR__.'/hootsuite_profiles_sync.php';
 
 function hootsuite_ensure_schema(PDO $pdo): void {
+    hootsuite_profiles_ensure_schema($pdo);
     try {
         $pdo->query('SELECT media_thumb_urls FROM hootsuite_posts LIMIT 1');
-        return; // schema up to date
     } catch (PDOException $e) {
         // continue to add missing columns
     }
@@ -37,6 +38,9 @@ function hootsuite_ensure_schema(PDO $pdo): void {
     foreach ($columns as $col) {
         try { $pdo->exec("ALTER TABLE hootsuite_posts ADD COLUMN $col"); } catch (PDOException $e) {}
     }
+    try {
+        $pdo->exec('ALTER TABLE hootsuite_posts ADD CONSTRAINT fk_hootsuite_profile FOREIGN KEY (social_profile_id) REFERENCES hootsuite_profiles(id)');
+    } catch (PDOException $e) {}
 }
 
 function hootsuite_extract_media(array $post): array {

--- a/public/calendar.php
+++ b/public/calendar.php
@@ -2,7 +2,6 @@
 require_once __DIR__.'/../lib/db.php';
 require_once __DIR__.'/../lib/calendar.php';
 require_once __DIR__.'/../lib/helpers.php';
-require_once __DIR__.'/../hoot/hootsuite_api.php';
 require_once __DIR__.'/../lib/auth.php';
 
 ensure_session();
@@ -20,29 +19,16 @@ header('Expires: 0');
 $store_id = $_SESSION['store_id'];
 $pdo = get_pdo();
 
-$stmt = $pdo->prepare('SELECT name, hootsuite_token FROM stores WHERE id = ?');
+$stmt = $pdo->prepare('SELECT name FROM stores WHERE id = ?');
 $stmt->execute([$store_id]);
 $store = $stmt->fetch();
 $store_name = $store['name'];
-$token = $store['hootsuite_token'] ?? null;
 
 $profile_map = [];
-$type_map = [
-    'facebookpage'      => 'facebook',
-    'instagrambusiness' => 'instagram',
-    'threads'           => 'threads',
-    'youtubechannel'    => 'youtube',
-    'pinterest'         => 'pinterest',
-    'twitter'           => 'x',
-    'linkedincompany'   => 'linkedin',
-    'tiktokbusiness'    => 'tiktok',
-];
-foreach (hootsuite_get_social_profiles($token) as $prof) {
-    if (!empty($prof['id'])) {
-        $type = strtolower($prof['type'] ?? '');
-        if (isset($type_map[$type])) {
-            $profile_map[$prof['id']] = $type_map[$type];
-        }
+$res = $pdo->query('SELECT id, network FROM hootsuite_profiles');
+foreach ($res as $prof) {
+    if (!empty($prof['id']) && !empty($prof['network'])) {
+        $profile_map[$prof['id']] = strtolower($prof['network']);
     }
 }
 

--- a/setup.php
+++ b/setup.php
@@ -114,6 +114,15 @@ $queries = [
         UNIQUE KEY name_unique (name)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
 
+    // Hootsuite profiles cache
+    "CREATE TABLE IF NOT EXISTS hootsuite_profiles (
+        id VARCHAR(50) PRIMARY KEY,
+        type VARCHAR(100) NULL,
+        username VARCHAR(255) NULL,
+        network VARCHAR(50) NULL,
+        raw TEXT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+
     // Upload status history table
     "CREATE TABLE IF NOT EXISTS upload_status_history (
         id INT AUTO_INCREMENT PRIMARY KEY,

--- a/update_database.php
+++ b/update_database.php
@@ -600,6 +600,20 @@ try {
     echo "✗ Error creating hootsuite_posts table: " . $e->getMessage() . "\n";
 }
 
+// Create Hootsuite profiles table
+try {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS hootsuite_profiles (
+        id VARCHAR(50) PRIMARY KEY,
+        type VARCHAR(100) NULL,
+        username VARCHAR(255) NULL,
+        network VARCHAR(50) NULL,
+        raw TEXT NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+    echo "✓ Created hootsuite_profiles table\n";
+} catch (PDOException $e) {
+    echo "✗ Error creating hootsuite_profiles table: " . $e->getMessage() . "\n";
+}
+
 $hootColumns = [
     'state VARCHAR(50)',
     'social_profile_id VARCHAR(50)',
@@ -625,6 +639,13 @@ $hootColumns = [
 ];
 foreach ($hootColumns as $col) {
     try { $pdo->exec("ALTER TABLE hootsuite_posts ADD COLUMN $col"); } catch (PDOException $e) { }
+}
+
+try {
+    $pdo->exec("ALTER TABLE hootsuite_posts ADD CONSTRAINT fk_hootsuite_profile FOREIGN KEY (social_profile_id) REFERENCES hootsuite_profiles(id)");
+    echo "✓ Added hootsuite_posts profile relation\n";
+} catch (PDOException $e) {
+    echo "ℹ︎ Could not add hootsuite profile relation: " . $e->getMessage() . "\n";
 }
 
 try {


### PR DESCRIPTION
## Summary
- cache all Hootsuite profiles in new `hootsuite_profiles` table and link posts to profiles
- update calendar and admin to use cached profiles and allow manual refresh
- add cron script to refresh Hootsuite profiles

## Testing
- `php -l hoot/hootsuite_profiles_sync.php`
- `php -l hoot/hootsuite_profiles_cron.php`
- `php -l hoot/hootsuite_profiles.php`
- `php -l hoot/hootsuite_sync.php`
- `php -l public/calendar.php`
- `php -l admin/settings.php`
- `php -l setup.php`
- `php -l update_database.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893dd4e96448326aa2e7cd7078ceeb3