### PR TITLE
Comment out Hootsuite fields and clarify refresh token button

### DIFF
--- a/admin/edit_store.php
+++ b/admin/edit_store.php
@@ -350,6 +350,7 @@ include __DIR__.'/header.php';
                                    value="<?php echo htmlspecialchars($store['hootsuite_campaign_tag']); ?>">
                             <div class="form-text">Must match the tag in Hootsuite</div>
                         </div>
+                        <!--
                         <div class="col-md-6">
                             <label for="hootsuite_campaign_id" class="form-label-modern">Hootsuite Campaign ID</label>
                             <div class="input-group">
@@ -358,6 +359,7 @@ include __DIR__.'/header.php';
                             </div>
                             <datalist id="campaigns_list"></datalist>
                         </div>
+                        -->
                         <div class="col-md-6">
                             <label for="hootsuite_profile_ids" class="form-label-modern">Hootsuite Profiles</label>
                             <input type="text" id="hootsuite_profile_search" class="form-control form-control-modern mb-2" placeholder="Search profiles">
@@ -366,6 +368,7 @@ include __DIR__.'/header.php';
                                     data-selected="<?php echo htmlspecialchars($store['hootsuite_profile_ids']); ?>"></select>
                             <div class="form-text">Select one or more profiles</div>
                         </div>
+                        <!--
                         <div class="col-md-6">
                             <label for="hootsuite_custom_property_key" class="form-label-modern">Hootsuite Custom Property Key</label>
                             <input type="text" name="hootsuite_custom_property_key" id="hootsuite_custom_property_key"
@@ -380,6 +383,7 @@ include __DIR__.'/header.php';
                                    value="<?php echo htmlspecialchars($store['hootsuite_custom_property_value']); ?>">
                             <div class="form-text">Required value for the custom property</div>
                         </div>
+                        -->
                         <div class="col-md-12">
                             <label for="marketing_report_url" class="form-label-modern">Marketing Report URL</label>
                             <input type="url" name="marketing_report_url" id="marketing_report_url"

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -972,7 +972,7 @@ include __DIR__.'/header.php';
                                     <strong>Sync Now</strong> adds new posts without clearing existing ones.
                                     <strong>Force Sync</strong> clears all posts then syncs.
                                     <strong>Erase All</strong> removes all stored posts.
-                                    <strong>Refresh Token</strong> obtains a new access token using the saved refresh token.
+                                    <strong>Refresh Token</strong> uses the saved refresh token to obtain a new access token.
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- hide unused Hootsuite campaign and custom property inputs on store edit page
- clarify what the Refresh Token action does in the Hootsuite settings

## Testing
- `php -l admin/edit_store.php`
- `php -l admin/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_6893eb3292bc8326a748c9a4c3923d6a