### PR TITLE
Improve schedule modal time picker and media preview

### DIFF
--- a/public/calendar.php
+++ b/public/calendar.php
@@ -764,15 +764,18 @@ include __DIR__.'/header.php';
                 var datePicker = flatpickr("#postDate", {
                     dateFormat: "m/d/Y",  // American date format
                     minDate: "today",
-                    disableMobile: true
+                    disableMobile: true,
+                    static: true
                 });
 
-                var timePicker = flatpickr("#postTime", {
+                window.timePicker = flatpickr("#postTime", {
                     enableTime: true,
                     noCalendar: true,
                     dateFormat: "h:i K",  // 12-hour format with AM/PM
                     time_24hr: false,
-                    disableMobile: true
+                    disableMobile: true,
+                    static: true,
+                    defaultDate: "12:00 PM"
                 });
 
                 document.getElementById('postDate').addEventListener('change', updateScheduledTime);
@@ -863,13 +866,13 @@ include __DIR__.'/header.php';
 
                 function displayMediaPreviews() {
                     if (selectedFiles.length === 0) {
-                        uploadContent.parentElement.style.display = 'block';
+                        uploadContent.style.display = 'block';
                         mediaPreviewGrid.style.display = 'none';
                         mediaPreviewGrid.innerHTML = '';
                         return;
                     }
 
-                    uploadContent.parentElement.style.display = 'none';
+                    uploadContent.style.display = 'none';
                     mediaPreviewGrid.style.display = 'grid';
                     mediaPreviewGrid.innerHTML = '';
 
@@ -959,7 +962,10 @@ include __DIR__.'/header.php';
 
                 // Clear date/time pickers
                 document.getElementById('postDate').value = '';
-                document.getElementById('postTime').value = '';
+                document.getElementById('postTime').value = '12:00 PM';
+                if (window.timePicker) {
+                    window.timePicker.setDate('12:00 PM', false);
+                }
                 document.getElementById('postSchedule').value = '';
 
                 document.getElementById('postAction').value = 'create';
@@ -983,7 +989,11 @@ include __DIR__.'/header.php';
                         var ampm = hours >= 12 ? 'PM' : 'AM';
                         hours = hours % 12;
                         hours = hours ? hours : 12;
-                        document.getElementById('postTime').value = hours + ':' + minutes.toString().padStart(2, '0') + ' ' + ampm;
+                        var timeValue = hours + ':' + minutes.toString().padStart(2, '0') + ' ' + ampm;
+                        document.getElementById('postTime').value = timeValue;
+                        if (window.timePicker) {
+                            window.timePicker.setDate(timeValue, false);
+                        }
                     }
                     if(eventObj.extendedProps.social_profile_id){
                         var checkbox = document.querySelector('.profile-checkbox-input[value="' + eventObj.extendedProps.social_profile_id + '"]');

--- a/public/inc/css/style.css
+++ b/public/inc/css/style.css
@@ -7151,6 +7151,8 @@ textarea.form-control-modern {
     padding: 1rem;
     background: #f8f9fa;
     border-radius: 12px;
+    max-height: 200px;
+    overflow-y: auto;
 }
 
 .media-preview-item {
@@ -7206,6 +7208,26 @@ textarea.form-control-modern {
     text-overflow: ellipsis;
     background: white;
     border-top: 1px solid #e9ecef;
+}
+
+/* Larger time picker controls */
+.flatpickr-time .numInputWrapper {
+    width: 70px;
+    height: 45px;
+}
+
+.flatpickr-time .numInputWrapper input {
+    font-size: 1.25rem;
+}
+
+.flatpickr-time .flatpickr-am-pm {
+    height: 45px;
+    font-size: 1.25rem;
+}
+
+.flatpickr-time .numInputWrapper span.arrowUp,
+.flatpickr-time .numInputWrapper span.arrowDown {
+    height: 45px;
 }
 
 /* Media Upload Area Dragging State */


### PR DESCRIPTION
## Summary
- Default schedule modal time to 12 PM and keep picker anchored on scroll
- Show media upload previews with remove buttons and scrolling
- Add styles for larger time picker controls

## Testing
- `php -l public/calendar.php`
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894da0f12608326aa8827b575ceb3ca