### PR TITLE
Define admin navbar height to prevent overlap

### DIFF
--- a/admin/inc/css/style.css
+++ b/admin/inc/css/style.css
@@ -1,4 +1,8 @@
 /* Admin styles */
+
+:root {
+    --admin-navbar-height: 72px;
+}
 .navbar-brand { font-weight: 600; }
 .navbar { background-color: #2c3e50 !important; }
 .card { border: 1px solid #dee2e6; }


### PR DESCRIPTION
## Summary
- add --admin-navbar-height variable and set to 72px
- ensures admin content and headers are offset below fixed navbar

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php tests/dbtest.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897419edc448326a3dceec1bd2f6586