### PR TITLE
Enable mobile modal scrolling in calendar

### DIFF
--- a/assets/css/mobile-optimizations.css
+++ b/assets/css/mobile-optimizations.css
@@ -378,6 +378,8 @@
     .modal-body {
         padding: 1rem;
         padding-bottom: calc(var(--ios-safe-area-bottom) + 1rem);
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
     }
     
     .modal-footer {


### PR DESCRIPTION
## Summary
- Allow scrolling inside mobile modals by enabling vertical overflow and iOS touch scrolling

## Testing
- `php -l public/calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_68a87b1738c48326acccb7b318d23607